### PR TITLE
fixing the issue when EDN parser can't parse function object

### DIFF
--- a/collet-cli/README.md
+++ b/collet-cli/README.md
@@ -59,3 +59,17 @@ bb build
 
 This will produce a `target/collet-cli.tar.gz` file.
 You can upload this file to GitHub releases.
+
+### Development
+
+When you are developing the collet-cli, you can use the following command to run the CLI.
+
+```shell
+bb --config ./collet-bb-deps.edn -f collet.bb -s /path/to/spec.edn -c /path/to/config.edn
+```
+
+In case you need a REPL to the babashka process
+
+```shell
+bb --config "./collet-bb-deps.edn" nrepl-server 1667
+```

--- a/collet-cli/collet.bb
+++ b/collet-cli/collet.bb
@@ -1,12 +1,13 @@
 #!/usr/bin/env bb
 
-(require
- '[babashka.pods :as pods]
- '[babashka.cli :as cli]
- '[babashka.fs :as fs]
- '[bblgum.core :as b]
- '[clojure.string :as string]
- '[puget.printer :as puget])
+(ns collet
+  (:require
+   [babashka.pods :as pods]
+   [babashka.cli :as cli]
+   [babashka.fs :as fs]
+   [bblgum.core :as b]
+   [clojure.string :as string]
+   [puget.printer :as puget]))
 
 
 (def pod-jar-path

--- a/collet-core/src/collet/utils.clj
+++ b/collet-core/src/collet/utils.clj
@@ -6,7 +6,7 @@
    [sci.core :as sci]
    [tech.v3.dataset :as ds])
   (:import
-   [clojure.lang PersistentVector]
+   [clojure.lang Fn PersistentVector]
    [ham_fisted LinkedHashMap]
    [sci.impl.opts Ctx]))
 
@@ -124,6 +124,7 @@
        (ds-seq? x) (list (ds/select-rows (first x) (range (min 100 (ds/row-count (first x))))))
        (ds/dataset? x) (ds/select-rows x (range (min 100 (ds/row-count x))))
        (and (sequential? x) (not (map-entry? x))) (take 100 x)
+       (fn? x) (-> ^Fn x .getClass .getName)
        :otherwise x))
    data))
 


### PR DESCRIPTION
- when error occurs in the collet pod babashka process is trying to read and parse that error. If error contains `#object` tag (from printing function object) parser will fail crashing the babashka process
- execute-task function should take `:state-format` into account to produce the correct result