### PR TITLE
fix: update dependencies for Java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  JAVA_VERSION: "21"
+  JAVA_VERSION: "25"
 
 jobs:
   unit:

--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ You can change this using the `JMX_PORT` environment variable.
 ### Collet as a library
 
 Collet core library heavily relies on latest Java features, such as virtual threads.
-So you'll need JDK 21 or higher to run it.
+Java 25 is the new minimum supported version, which is a compatibility break from
+previous releases. You'll need JDK 25 or higher to run it.
 Add the following dependency to your project:
 Replace `VERSION` with the release version you use.
 

--- a/bb.edn
+++ b/bb.edn
@@ -22,6 +22,7 @@
 
     (defn test-integration! []
       (shell "clojure" "-T:build" "build" ":module" ":collet-cli")
+      (shell "clojure" "-P" "-X:build-test")
       (shell "clojure" "-M:kmono" "run" "--M" ":test:integration"
              "--" "-i" ":integration")))
 

--- a/build/test/collet/build_test.clj
+++ b/build/test/collet/build_test.clj
@@ -89,6 +89,18 @@
          (set (get-in (edn/read-string (slurp "deps.edn"))
                       [:kmono/workspace :ignore-changes])))))
 
+(deftest integration-tests-prefetch-git-dependencies-before-parallel-packages
+  (let [init-form (:init (:tasks (edn/read-string (slurp "bb.edn"))))
+        task-form (some #(when (and (seq? %)
+                                    (= 'defn (first %))
+                                    (= 'test-integration! (second %)))
+                           %)
+                        (rest init-form))]
+    (is (= '((shell "clojure" "-P" "-X:build-test")
+             (shell "clojure" "-M:kmono" "run" "--M" ":test:integration"
+                    "--" "-i" ":integration"))
+           (take-last 2 (drop 3 task-form))))))
+
 (deftest load-packages-bootstraps-the-full-workspace-at-0-2-8
   (with-workspace
     (fn [root]

--- a/build/test/collet/verify_test.clj
+++ b/build/test/collet/verify_test.clj
@@ -20,7 +20,7 @@
               :deps {'example/core {:local/root "../core"}
                      'external/dep {:mvn/version "4.5.6"}
                      ;; Mirrors Vega's public POM-only runtime coordinate.
-                     'example/vega-runtime {:mvn/version "24.2.2"
+                     'example/vega-runtime {:mvn/version "25.1.3"
                                             :extension "pom"}
                      ;; Mirrors the queue artifact's preserved exclusions.
                      'example/queue {:mvn/version "0.2.1"
@@ -81,7 +81,7 @@
           (str "<dependency><groupId>external</groupId><artifactId>dep</artifactId>"
                "<version>" external-version "</version></dependency>"))
         "<dependency><groupId>example</groupId><artifactId>vega-runtime</artifactId>"
-        "<version>24.2.2</version><type>" vega-type "</type></dependency>"
+        "<version>25.1.3</version><type>" vega-type "</type></dependency>"
         "<dependency><groupId>example</groupId><artifactId>queue</artifactId>"
         "<version>0.2.1</version><exclusions>"
         (apply str

--- a/collet-action-file/deps.edn
+++ b/collet-action-file/deps.edn
@@ -5,11 +5,11 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure          {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure          {:mvn/version "1.12.5"}
         io.velio/collet-core         {:local/root "../collet-core"}
         io.velio/collet-action-http  {:local/root "../collet-action-http"}
-        com.cnuernber/charred        {:mvn/version "1.034"}
-        techascent/tech.ml.dataset   {:mvn/version "7.032"}}
+        com.cnuernber/charred        {:mvn/version "1.041"}
+        techascent/tech.ml.dataset   {:mvn/version "8.024"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}

--- a/collet-action-http/deps.edn
+++ b/collet-action-http/deps.edn
@@ -5,11 +5,11 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure        {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure        {:mvn/version "1.12.5"}
         io.velio/collet-core       {:local/root "../collet-core"}
         hato/hato                  {:mvn/version "1.0.0"}
-        com.cnuernber/charred      {:mvn/version "1.034"}
-        diehard/diehard            {:mvn/version "0.11.12"}}
+        com.cnuernber/charred      {:mvn/version "1.041"}
+        diehard/diehard            {:mvn/version "0.12.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-action-jdbc/deps.edn
+++ b/collet-action-jdbc/deps.edn
@@ -5,17 +5,17 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure                    {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure                    {:mvn/version "1.12.5"}
         io.velio/collet-core                   {:local/root "../collet-core"}
-        com.cnuernber/charred                  {:mvn/version "1.034"}
-        com.github.seancorfield/next.jdbc      {:mvn/version "1.3.955"}
-        com.github.seancorfield/honeysql       {:mvn/version "2.6.1196"}
-        techascent/tech.ml.dataset             {:mvn/version "7.032"}
-        org.postgresql/postgresql              {:mvn/version "42.7.4"}}
+        com.cnuernber/charred                  {:mvn/version "1.041"}
+        com.github.seancorfield/next.jdbc      {:mvn/version "1.3.1118"}
+        com.github.seancorfield/honeysql       {:mvn/version "2.7.1399"}
+        techascent/tech.ml.dataset             {:mvn/version "8.024"}
+        org.postgresql/postgresql              {:mvn/version "42.7.13"}}
  :aliases
   {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}
-                      com.mysql/mysql-connector-j {:mvn/version "9.0.0"}}
+                      com.mysql/mysql-connector-j {:mvn/version "9.7.0"}}
          :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
                     "--enable-native-access=ALL-UNNAMED"]
          :main-opts ["-m" "cognitect.test-runner"]}

--- a/collet-action-jdbc/test/collet/actions/jdbc_test.clj
+++ b/collet-action-jdbc/test/collet/actions/jdbc_test.clj
@@ -421,7 +421,7 @@
     (testing "execute pipeline with jdbc action"
       (let [pipeline (collet/compile-pipeline
                       {:name  :employees
-                       :deps  {:coordinates '[[com.mysql/mysql-connector-j "9.0.0"]]}
+                       :deps  {:coordinates '[[com.mysql/mysql-connector-j "9.7.0"]]}
                        :tasks [{:name       :query
                                 :keep-state true
                                 :actions    [{:name      :query-action
@@ -499,7 +499,7 @@
     (testing "query with join tables"
       (let [pipeline (collet/compile-pipeline
                       {:name      :products-bought-by-users
-                       :deps      {:coordinates '[[com.mysql/mysql-connector-j "9.0.0"]]}
+                       :deps      {:coordinates '[[com.mysql/mysql-connector-j "9.7.0"]]}
                        :use-arrow false
                        :tasks     [{:name       :query
                                     :keep-state true

--- a/collet-action-jslt/deps.edn
+++ b/collet-action-jslt/deps.edn
@@ -5,9 +5,9 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure            {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure            {:mvn/version "1.12.5"}
         io.velio/collet-core           {:local/root "../collet-core"}
-        metosin/malli                  {:mvn/version "0.16.4"}
+        metosin/malli                  {:mvn/version "0.20.1"}
         com.schibsted.spt.data/jslt    {:mvn/version "0.1.14"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/collet-action-llm/deps.edn
+++ b/collet-action-llm/deps.edn
@@ -5,12 +5,12 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure               {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure               {:mvn/version "1.12.5"}
         io.velio/collet-core              {:local/root "../collet-core"}
-        com.cnuernber/charred             {:mvn/version "1.034"}
-        metosin/malli                     {:mvn/version "0.16.4"}
-        net.clojars.wkok/openai-clojure   {:mvn/version "0.22.0"}
-        org.apache.tika/tika-core         {:mvn/version "2.9.2"}}
+        com.cnuernber/charred             {:mvn/version "1.041"}
+        metosin/malli                     {:mvn/version "0.20.1"}
+        net.clojars.wkok/openai-clojure   {:mvn/version "0.23.0"}
+        org.apache.tika/tika-core         {:mvn/version "3.3.2"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-action-lucene/deps.edn
+++ b/collet-action-lucene/deps.edn
@@ -5,13 +5,13 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure                     {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure                     {:mvn/version "1.12.5"}
         io.velio/collet-core                    {:local/root "../collet-core"}
-        metosin/malli                           {:mvn/version "0.16.4"}
-        techascent/tech.ml.dataset              {:mvn/version "7.032"}
-        org.apache.lucene/lucene-core           {:mvn/version "10.3.2"}
-        org.apache.lucene/lucene-queryparser    {:mvn/version "10.3.2"}
-        org.apache.lucene/lucene-analyzers-common {:mvn/version "8.11.4"}}
+        metosin/malli                           {:mvn/version "0.20.1"}
+        techascent/tech.ml.dataset              {:mvn/version "8.024"}
+        org.apache.lucene/lucene-core           {:mvn/version "10.5.0"}
+        org.apache.lucene/lucene-queryparser    {:mvn/version "10.5.0"}
+        org.apache.lucene/lucene-analysis-common {:mvn/version "10.5.0"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-action-lucene/src/collet/actions/lucene.clj
+++ b/collet-action-lucene/src/collet/actions/lucene.clj
@@ -1014,7 +1014,8 @@
 
 
 (def expression-parser
-  (m/parser ::expression {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser ::expression {:registry registry})))
 
 
 (defn dispatch-fn [x]

--- a/collet-action-odata/deps.edn
+++ b/collet-action-odata/deps.edn
@@ -5,10 +5,10 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure         {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure         {:mvn/version "1.12.5"}
         io.velio/collet-core        {:local/root "../collet-core"}
         io.velio/collet-action-http {:local/root "../collet-action-http"}
-        metosin/malli               {:mvn/version "0.16.4"}}
+        metosin/malli               {:mvn/version "0.20.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-action-odata/src/collet/actions/odata.clj
+++ b/collet-action-odata/src/collet/actions/odata.clj
@@ -107,19 +107,24 @@
 
 
 (def segment-parser
-  (m/parser segment-spec {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser segment-spec {:registry registry})))
 
 (def filter-parser
-  (m/parser filter-spec {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser filter-spec {:registry registry})))
 
 (def select-parser
-  (m/parser select-spec {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser select-spec {:registry registry})))
 
 (def order-by-parser
-  (m/parser order-by-spec {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser order-by-spec {:registry registry})))
 
 (def expand-parser
-  (m/parser expand-spec {:registry registry}))
+  (comp m/old-parse-format
+        (m/parser expand-spec {:registry registry})))
 
 
 (defn dispatch-fn [x]

--- a/collet-action-queue/deps.edn
+++ b/collet-action-queue/deps.edn
@@ -5,16 +5,16 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure          {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure          {:mvn/version "1.12.5"}
         io.velio/collet-core         {:local/root "../collet-core"}
-        techascent/tech.ml.dataset   {:mvn/version "7.032"}
+        techascent/tech.ml.dataset   {:mvn/version "8.024"}
         io.zalky/cues                {:mvn/version "0.2.1"
                                       :exclusions [com.taoensso/encore
                                                    net.openhft/chronicle-queue]}
-        com.taoensso/encore          {:mvn/version "3.122.0"}
-        net.openhft/chronicle-queue  {:mvn/version "5.26ea5"
+        com.taoensso/encore          {:mvn/version "3.169.1"}
+        net.openhft/chronicle-queue  {:mvn/version "2026.5"
                                       :exclusions [net.openhft/chronicle-analytics]}
-        org.slf4j/slf4j-nop          {:mvn/version "2.0.16"}}
+        org.slf4j/slf4j-nop          {:mvn/version "2.0.18"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}
@@ -27,6 +27,6 @@
                     "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
                     "--add-opens=java.base/java.io=ALL-UNNAMED"
                     "--add-opens=java.base/java.util=ALL-UNNAMED"
-                    "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+                    "--add-opens=java.base/java.nio=ALL-UNNAMED"
                     "--enable-native-access=ALL-UNNAMED"]
          :main-opts ["-m" "cognitect.test-runner"]}}}

--- a/collet-action-s3/deps.edn
+++ b/collet-action-s3/deps.edn
@@ -5,17 +5,17 @@
   :kind :library}
 
  :paths ["src"]
- :deps {org.clojure/clojure         {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure         {:mvn/version "1.12.5"}
         io.velio/collet-core        {:local/root "../collet-core"}
         io.velio/collet-action-file {:local/root "../collet-action-file"}
-        diehard/diehard             {:mvn/version "0.11.12"}
-        com.cognitect.aws/api       {:mvn/version "0.8.692"}
-        com.cognitect.aws/endpoints {:mvn/version "1.1.12.772"}
-        com.cognitect.aws/s3        {:mvn/version "869.2.1687.0"}}
+        diehard/diehard             {:mvn/version "0.12.1"}
+        com.cognitect.aws/api       {:mvn/version "0.8.838"}
+        com.cognitect.aws/endpoints {:mvn/version "871.2.47.0"}
+        com.cognitect.aws/s3        {:mvn/version "871.2.46.17"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}
-                      com.cnuernber/charred {:mvn/version "1.034"}}
+                      com.cnuernber/charred {:mvn/version "1.041"}}
          :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
                     "--enable-native-access=ALL-UNNAMED"]
          :main-opts ["-m" "cognitect.test-runner"]}

--- a/collet-action-vega/deps.edn
+++ b/collet-action-vega/deps.edn
@@ -5,12 +5,12 @@
   :kind :library}
 
  :paths ["src" "resources"]
- :deps {org.clojure/clojure         {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure         {:mvn/version "1.12.5"}
         io.velio/collet-core        {:local/root "../collet-core"}
         io.velio/collet-action-file {:local/root "../collet-action-file"}
-        com.cnuernber/charred       {:mvn/version "1.034"}
-        org.graalvm.polyglot/js     {:mvn/version "24.2.2" :extension "pom"}
-        org.graalvm.js/js-scriptengine {:mvn/version "24.2.2"}}
+        com.cnuernber/charred       {:mvn/version "1.041"}
+        org.graalvm.polyglot/js     {:mvn/version "25.1.3" :extension "pom"}
+        org.graalvm.js/js-scriptengine {:mvn/version "25.1.3"}}
  :aliases
  {:test {:extra-paths ["test" "test-resources"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}

--- a/collet-actions/deps.edn
+++ b/collet-actions/deps.edn
@@ -10,7 +10,7 @@
   :kind :library}
 
  :paths []
- :deps {org.clojure/clojure             {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure             {:mvn/version "1.12.5"}
         io.velio/collet-action-http     {:local/root "../collet-action-http"}
         io.velio/collet-action-file     {:local/root "../collet-action-file"}
         io.velio/collet-action-odata    {:local/root "../collet-action-odata"}

--- a/collet-app/Dockerfile
+++ b/collet-app/Dockerfile
@@ -2,7 +2,7 @@ ARG COLLET_CORE_VERSION="0.0.0-local"
 ARG COLLET_VERSION="0.0.0-local"
 ARG COLLET_REVISION="docker-build"
 
-FROM clojure:temurin-21-tools-deps AS builder
+FROM clojure:temurin-25-tools-deps AS builder
 
 ARG COLLET_CORE_VERSION
 ARG COLLET_VERSION
@@ -21,7 +21,7 @@ RUN clojure -T:build build :module :collet-app \
                   io.velio/collet-app \"${COLLET_VERSION}\"}"
 
 
-FROM eclipse-temurin:21.0.5_11-jre
+FROM eclipse-temurin:25.0.3_9-jre
 
 ARG COLLET_VERSION
 ARG COLLET_REVISION
@@ -45,11 +45,13 @@ RUN mkdir /app/jmx
 COPY collet-app/resources/jmx_prometheus_javaagent-0.20.0.jar /app/jmx/jmx_prometheus_javaagent-0.20.0.jar
 COPY collet-app/resources/jmx.yaml /app/jmx/jmx.yaml
 
-
 ARG TARGETPLATFORM
 ARG TINI_ARCH
+ARG WGET_VERSION=1.25.0-2ubuntu4.3
 
-RUN echo "Building for ${TARGETPLATFORM}" && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget="${WGET_VERSION}" && \
+    echo "Building for ${TARGETPLATFORM}" && \
     case ${TARGETPLATFORM} in \
          "linux/amd64")  TINI_ARCH=amd64  ;; \
          "linux/arm64")  TINI_ARCH=arm64  ;; \
@@ -57,7 +59,9 @@ RUN echo "Building for ${TARGETPLATFORM}" && \
          "linux/arm/v6") TINI_ARCH=armel  ;; \
          "linux/386")    TINI_ARCH=i386   ;; \
     esac && \
-    wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}
+    wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH} && \
+    apt-get purge -y --auto-remove wget && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN chmod +x /tini
 
@@ -76,7 +80,7 @@ CMD java \
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
 --add-opens=java.base/java.io=ALL-UNNAMED \
 --add-opens=java.base/java.util=ALL-UNNAMED \
---add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED \
+--add-opens=java.base/java.nio=ALL-UNNAMED \
 --enable-native-access=ALL-UNNAMED \
 -javaagent:/app/jmx/jmx_prometheus_javaagent-0.20.0.jar=$JMX_PORT:/app/jmx/jmx.yaml \
 -jar collet.jar -s "${PIPELINE_SPEC}" -c "${PIPELINE_CONFIG}"

--- a/collet-app/deploy.md
+++ b/collet-app/deploy.md
@@ -1,7 +1,8 @@
 # Application deployment
 
-The application requires JDK 21 or newer. Build its preserved uberjar filename from
-the repository root:
+The application requires JDK 25 or newer. Java 25 is the new minimum supported
+version, which is a compatibility break from previous releases. Build its preserved
+uberjar filename from the repository root:
 
 ```shell
 bb build collet-app
@@ -30,9 +31,9 @@ docker run --rm \
   collet
 ```
 
-The builder uses Clojure CLI with JDK 21. The runtime image preserves the existing
-JVM options, JMX agent on port 8080, `/tini` entrypoint, environment variables, and
-startup command.
+The builder uses Clojure CLI with JDK 25 and the runtime image uses Java 25. The
+runtime image preserves the existing JVM options, JMX agent on port 8080, `/tini`
+entrypoint, environment variables, and startup command.
 
 Docker is required for this workflow. The repository release command creates the app
 package tag but never builds or pushes a registry image; image publication is a

--- a/collet-app/deps.edn
+++ b/collet-app/deps.edn
@@ -7,17 +7,17 @@
   :outputs {:uberjar "target/collet.jar"}}
 
  :paths ["src" "resources"]
- :deps {org.clojure/clojure                  {:mvn/version "1.12.0"}
-        org.clojure/java.jmx                 {:mvn/version "1.1.0"}
-        org.clojure/tools.cli                {:mvn/version "1.1.230"}
+ :deps {org.clojure/clojure                  {:mvn/version "1.12.5"}
+        org.clojure/java.jmx                 {:mvn/version "1.1.1"}
+        org.clojure/tools.cli                {:mvn/version "1.4.256"}
         io.velio/collet-core                 {:local/root "../collet-core"}
-        com.brunobonacci/mulog               {:mvn/version "0.9.0"}
-        com.brunobonacci/mulog-zipkin        {:mvn/version "0.9.0"}
-        com.brunobonacci/mulog-elasticsearch {:mvn/version "0.9.0"}
-        org.slf4j/slf4j-nop                  {:mvn/version "2.0.16"}
-        com.cognitect.aws/api                {:mvn/version "0.8.692"}
-        com.cognitect.aws/endpoints          {:mvn/version "1.1.12.772"}
-        com.cognitect.aws/s3                 {:mvn/version "869.2.1687.0"}}
+        com.brunobonacci/mulog               {:mvn/version "0.10.1"}
+        com.brunobonacci/mulog-zipkin        {:mvn/version "0.10.1"}
+        com.brunobonacci/mulog-elasticsearch {:mvn/version "0.10.1"}
+        org.slf4j/slf4j-nop                  {:mvn/version "2.0.18"}
+        com.cognitect.aws/api                {:mvn/version "0.8.838"}
+        com.cognitect.aws/endpoints          {:mvn/version "871.2.47.0"}
+        com.cognitect.aws/s3                 {:mvn/version "871.2.46.17"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-cli/README.md
+++ b/collet-cli/README.md
@@ -82,8 +82,9 @@ partially publishes Maven artifacts, follow the manual recovery steps in the
 
 ### Development
 
-Building requires JDK 21 or newer, Clojure CLI, and Babashka. Run the pod artifact
-startup test with:
+Building requires JDK 25 or newer, Clojure CLI, and Babashka. Java 25 is the new
+minimum supported version, which is a compatibility break from previous releases.
+Run the pod artifact startup test with:
 
 ```shell
 bb test:module collet-cli

--- a/collet-cli/collet-bb-deps.edn
+++ b/collet-cli/collet-bb-deps.edn
@@ -1,5 +1,5 @@
 {:deps
- {org.babashka/cli             {:mvn/version "0.8.60"}
-  babashka/fs                  {:mvn/version "0.5.24"}
-  io.github.lispyclouds/bblgum {:git/sha "1d4de3d49b84f64d1b71930fa1161f8d2622a4d9"}
+ {org.babashka/cli             {:mvn/version "0.12.77"}
+  babashka/fs                  {:mvn/version "0.5.34"}
+  io.github.lispyclouds/bblgum {:git/sha "881a426d9df9df40eb305ceaeb3996ea1c7ae0d3"}
   mvxcvi/puget                 {:mvn/version "1.3.4"}}}

--- a/collet-cli/collet.bb
+++ b/collet-cli/collet.bb
@@ -25,7 +25,7 @@
   "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
   "--add-opens=java.base/java.io=ALL-UNNAMED"
   "--add-opens=java.base/java.util=ALL-UNNAMED"
-  "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+  "--add-opens=java.base/java.nio=ALL-UNNAMED"
   "--enable-native-access=ALL-UNNAMED"
   "-jar" pod-jar-path])
 (require '[pod.collet.core :as collet])

--- a/collet-cli/deps.edn
+++ b/collet-cli/deps.edn
@@ -14,10 +14,10 @@
            {:from "gum" :to "gum" :mode "rwxr-xr-x"}]}}
 
  :paths ["src"]
- :deps {org.clojure/clojure    {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure    {:mvn/version "1.12.5"}
         io.velio/collet-app    {:local/root "../collet-app"}
-        nrepl/bencode          {:mvn/version "1.1.0"}
-        djblue/portal          {:mvn/version "0.58.2"}}
+        nrepl/bencode          {:mvn/version "1.2.0"}
+        djblue/portal          {:mvn/version "0.67.0"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.velio/collet-test-fixtures {:local/root "../test-fixtures"}}

--- a/collet-core/deps.edn
+++ b/collet-core/deps.edn
@@ -6,22 +6,22 @@
 
  :paths ["src" "resources"]
  :deps
- {org.clojure/clojure                  {:mvn/version "1.12.0"}
-  weavejester/dependency               {:mvn/version "0.2.1"}
-  metosin/malli                        {:mvn/version "0.16.4"}
-  diehard/diehard                      {:mvn/version "0.11.12"}
-  clj-commons/pomegranate              {:mvn/version "1.2.24"}
-  org.babashka/sci                     {:mvn/version "0.9.44"}
-  com.brunobonacci/mulog               {:mvn/version "0.9.0"}
-  org.slf4j/slf4j-nop                  {:mvn/version "2.0.16"}
-  techascent/tech.ml.dataset           {:mvn/version "7.032"}
-  org.apache.arrow/arrow-vector        {:mvn/version "18.1.0"}
-  org.apache.arrow/arrow-memory-netty  {:mvn/version "18.1.0"}
+ {org.clojure/clojure                  {:mvn/version "1.12.5"}
+  weavejester/dependency               {:mvn/version "1.0.1"}
+  metosin/malli                        {:mvn/version "0.20.1"}
+  diehard/diehard                      {:mvn/version "0.12.1"}
+  clj-commons/pomegranate              {:mvn/version "1.3.27"}
+  org.babashka/sci                     {:mvn/version "0.15.56"}
+  com.brunobonacci/mulog               {:mvn/version "0.10.1"}
+  org.slf4j/slf4j-nop                  {:mvn/version "2.0.18"}
+  techascent/tech.ml.dataset           {:mvn/version "8.024"}
+  org.apache.arrow/arrow-vector        {:mvn/version "19.0.0"}
+  org.apache.arrow/arrow-memory-unsafe {:mvn/version "19.0.0"}
   com.cnuernber/jarrow                 {:mvn/version "1.000"}
-  org.apache.commons/commons-compress  {:mvn/version "1.21"}
-  org.lz4/lz4-java                     {:mvn/version "1.8.0"}
-  net.java.dev.jna/jna                 {:mvn/version "5.10.0"}
-  com.github.luben/zstd-jni            {:mvn/version "1.5.4-1"}}
+  org.apache.commons/commons-compress  {:mvn/version "1.28.0"}
+  at.yawk.lz4/lz4-java                  {:mvn/version "1.8.1"}
+  net.java.dev.jna/jna                 {:mvn/version "5.19.1"}
+  com.github.luben/zstd-jni            {:mvn/version "1.5.7-11"}}
  :aliases
  {:test
   {:extra-paths ["test"]
@@ -38,11 +38,11 @@
                  "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
                  "--add-opens=java.base/java.io=ALL-UNNAMED"
                  "--add-opens=java.base/java.util=ALL-UNNAMED"
-                 "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+                 "--add-opens=java.base/java.nio=ALL-UNNAMED"
                  "--enable-native-access=ALL-UNNAMED"]
    :main-opts   ["-m" "cognitect.test-runner"]}
   :dev
   {:extra-paths ["dev/src"]
    :extra-deps  {eftest/eftest                 {:mvn/version "0.6.0"}
                  vvvvalvalval/scope-capture    {:mvn/version "0.3.3"}
-                 djblue/portal                 {:mvn/version "0.58.2"}}}}}
+                 djblue/portal                 {:mvn/version "0.67.0"}}}}}

--- a/collet-core/test/collet/actions/enrich_test.clj
+++ b/collet-core/test/collet/actions/enrich_test.clj
@@ -68,7 +68,7 @@
 (deftest enrich-data-pipeline-test
   (testing "enrich action in the context of pipeline execution"
     (let [pipeline-spec {:name  :city-events-with-artists
-                         :deps  {:coordinates '[[io.velio/collet-actions "0.2.7"]]}
+                         :deps  {:coordinates '[[io.velio/collet-actions "0.2.9"]]}
                          :tasks [{:name       :events-with-artists
                                   :keep-state true
                                   :setup      [{:type      :slicer

--- a/collet-core/test/collet/actions/enrich_test.clj
+++ b/collet-core/test/collet/actions/enrich_test.clj
@@ -68,7 +68,7 @@
 (deftest enrich-data-pipeline-test
   (testing "enrich action in the context of pipeline execution"
     (let [pipeline-spec {:name  :city-events-with-artists
-                         :deps  {:coordinates '[[io.velio/collet-actions "0.2.9"]]}
+                         :deps  {:coordinates '[[io.velio/collet-actions "0.2.8"]]}
                          :tasks [{:name       :events-with-artists
                                   :keep-state true
                                   :setup      [{:type      :slicer

--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,7 @@
              "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
              "--add-opens=java.base/java.io=ALL-UNNAMED"
              "--add-opens=java.base/java.util=ALL-UNNAMED"
-             "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+             "--add-opens=java.base/java.nio=ALL-UNNAMED"
              "--enable-native-access=ALL-UNNAMED"]}
 
  :paths []

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -612,7 +612,7 @@ The request map can contain the following keys:
 ```clojure
 {:name  :products-bought-by-users
  :deps  {:coordinates [[io.velio/collet-actions "VERSION"]
-                       [com.mysql/mysql-connector-j "9.0.0"]]}
+                       [com.mysql/mysql-connector-j "9.7.0"]]}
  :tasks [{:name    :query
           :actions [{:name   :query-action
                      :type   :collet.actions.jdbc/query

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,8 @@ artifact contract in its own `deps.edn` under `:collet/artifact`.
 
 ## Prerequisites
 
-- JDK 21 or newer. CI runs on JDK 21.
+- JDK 25 or newer. CI runs on JDK 25. Java 25 is the new minimum supported
+  version, which is a compatibility break from previous releases.
 - Clojure CLI.
 - Babashka.
 - Docker for PostgreSQL, MySQL, LocalStack, application/CLI startup, and image
@@ -87,7 +88,7 @@ Use one of these kinds:
 | `docs` | Documentation-only changes | `docs/122-release-recovery` |
 | `test` | Test-only changes | `test/96-http-retry` |
 | `refactor` | Internal restructuring with no behavior change | `refactor/81-action-registration` |
-| `ci` | CI and automation changes | `ci/77-jdk-21-cache` |
+| `ci` | CI and automation changes | `ci/77-jdk-25-cache` |
 | `chore` | Maintenance that does not fit another kind | `chore/update-testcontainers` |
 
 Include the GitHub issue number when the work has one. For small untracked

--- a/docs/module-migration.md
+++ b/docs/module-migration.md
@@ -85,7 +85,7 @@ versions. This conversion is owned by Kmono, not a Collet dependency-rewrite lay
 The former unpublished `lib/darkstar.jar` is not part of the build. The Vega module
 packages the required existing source/resources directly and includes upstream MIT
 license attribution and provenance under `META-INF`. Graal versions remain pinned at
-24.2.2. Vega tests compare rendered output with the preserved golden result.
+25.1.3. Vega tests compare rendered output with the preserved golden result.
 
 ## Application and CLI contracts
 

--- a/docs/module-migration.md
+++ b/docs/module-migration.md
@@ -95,8 +95,10 @@ license attribution and provenance under `META-INF`. Graal versions remain pinne
   `pod.collet.core`.
 - The CLI archive remains `collet-cli/target/collet-cli.tar.gz`, rooted at
   `collet-cli/`, with executable `collet.bb` and `gum` files.
-- Docker uses a Clojure CLI/JDK 21 builder and retains the existing runtime image,
-  JVM options, JMX setup, entrypoint, and environment contract.
+- Docker uses a Clojure CLI/JDK 25 builder and Java 25 runtime image, retaining the
+  existing JVM options, JMX setup, entrypoint, and environment contract. Java 25 is
+  the new minimum supported version, which is a compatibility break from previous
+  releases.
 
 ## Version policy
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,7 +39,8 @@ dependency graph, publication client, release transaction, or recovery journal.
 
 ## Prerequisites
 
-- JDK 21 or newer, Clojure CLI, and Babashka.
+- JDK 25 or newer, Clojure CLI, and Babashka. Java 25 is the new minimum supported
+  version, which is a compatibility break from previous releases.
 - Docker for `bb test` and the integration suite.
 - A clean local `main` exactly synchronized with `origin/main`.
 - Clojars credentials in Maven's standard `~/.m2/settings.xml` file.

--- a/examples/github-developer-productivity/github-productivity-pipeline.edn
+++ b/examples/github-developer-productivity/github-productivity-pipeline.edn
@@ -1,6 +1,6 @@
 {:name  :devs-productivity-pipeline
  ;; add extra dependencies
- :deps  {:coordinates [[io.velio/collet-actions "0.2.7"]]
+ :deps  {:coordinates [[io.velio/collet-actions "0.2.9"]]
          :imports     [java.lang.Math
                        java.time.LocalDate
                        java.time.LocalDateTime
@@ -180,4 +180,3 @@
                                  :format      :csv
                                  :csv-header? true
                                  :file-name   "./reports/average-time-to-merge.csv"}}]}]}
-

--- a/examples/image-object-detection/object-detection-pipeline.edn
+++ b/examples/image-object-detection/object-detection-pipeline.edn
@@ -1,5 +1,5 @@
 {:name  :image-object-detection
- :deps  {:coordinates [[io.velio/collet-actions "0.2.7"]
+ :deps  {:coordinates [[io.velio/collet-actions "0.2.9"]
                        [remus/remus "0.2.4"]
                        [enlive "1.1.6"]]
          :requires    [[clojure.string :as string]

--- a/test-fixtures/deps.edn
+++ b/test-fixtures/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src" "resources"]
- :deps  {org.clojure/clojure                  {:mvn/version "1.12.0"}
-         com.cnuernber/charred                {:mvn/version "1.034"}
-         metosin/malli                        {:mvn/version "0.16.4"}
-         com.github.seancorfield/next.jdbc    {:mvn/version "1.3.955"}
+ :deps  {org.clojure/clojure                  {:mvn/version "1.12.5"}
+         com.cnuernber/charred                {:mvn/version "1.041"}
+         metosin/malli                        {:mvn/version "0.20.1"}
+         com.github.seancorfield/next.jdbc    {:mvn/version "1.3.1118"}
          clj-test-containers/clj-test-containers
          {:mvn/version "0.7.4"}
-         org.testcontainers/testcontainers    {:mvn/version "1.21.4"}
+         org.testcontainers/testcontainers    {:mvn/version "2.0.5"}
          io.github.cognitect-labs/test-runner
          {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}


### PR DESCRIPTION
## Summary

- upgrade direct runtime, test, build, and CLI dependencies to the latest stable versions
- move CI, application images, and documentation to Java 25
- align all 14 Collet packages for the planned 0.2.9 release

## Compatibility

- Java 25 is now the minimum supported runtime
- preserve OData and Lucene parser output by adapting Malli 0.20 parsers with `m/old-parse-format`
- switch Arrow 19 to `arrow-memory-unsafe` because its Netty allocator fails under Java 25
- migrate renamed LZ4 and Lucene artifact coordinates
- keep the Maven-resolving core fixture on published Collet 0.2.8 while release-facing examples target 0.2.9
- intentionally classify the Java minimum change as a pre-1.0 patch exception

## Validation

- `bb test` — complete unit and Docker integration suite
- `bb verify`
- Java 25 Docker build and startup — Temurin 25.0.3+9, Tini 0.19.0, no retained wget
- manifest alignment and obsolete-coordinate audits
- `bb release:plan` — all 14 packages plan at 0.2.9 (13 Maven artifacts plus tag-only CLI)
- independent whole-branch review found no remaining issues