### PR TITLE
chore: add agent REPL tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,221 @@
+# Repository Guidelines
+
+## Project Snapshot
+
+Collet is a modular Clojure workflow engine for declarative ETL and ELT
+pipelines. The repository is a Clojure CLI workspace resolved by Kmono: each
+runtime library or executable has its own `deps.edn`, tests, artifact contract,
+and independent release tag.
+
+This is not a single-classpath monolith. Keep implementation, dependencies,
+tests, resources, and artifact metadata in the package that owns them.
+
+## Start Here
+
+- Read `README.md` for the pipeline and action model.
+- Read `docs/development.md` before changing packages, dependencies, builds, or
+  releases.
+- Read `docs/repl-workflow.md` before editing Clojure.
+- Read only the task-relevant action, syntax, migration, or release docs.
+- Treat this file as the routing layer, not the complete manual.
+
+## Repository Map
+
+| Area | Paths |
+| --- | --- |
+| Pipeline engine | `collet-core/src/`, `collet-core/test/` |
+| Individual actions | `collet-action-*/src/`, `collet-action-*/test/` |
+| Compatibility aggregate | `collet-actions/` |
+| JVM application | `collet-app/` |
+| Babashka pod and CLI | `collet-cli/` |
+| Shared test fixtures | `test-fixtures/` |
+| Build and release tooling | `build/src/`, `build/test/`, `bb.edn` |
+| Examples and docs | `examples/`, `docs/`, `README.md` |
+| Agent tooling | `dev/user.clj`, `scripts/agent/` |
+
+## Golden Commands
+
+Run repository-level commands from the repository root.
+
+| Task | Command |
+| --- | --- |
+| Start the worktree nREPL | `clojure -M:dev:nrepl` |
+| Discover nREPL ports | `clj-nrepl-eval --discover-ports` |
+| Discover ports with the fallback client | `bb scripts/agent/nrepl-eval.bb --discover` |
+| Reload changed project code | `clj-nrepl-eval -p <port> "(user/reload)"` |
+| Repair Clojure delimiters | `clj-paren-repair path/to/file.clj` |
+| Inspect the package graph | `bb kmono query` |
+| Test one package | `bb test:module <module>` |
+| Run non-integration tests | `bb test:unit` |
+| Run Docker integration tests | `bb test:integration` |
+| Run every test | `bb test` |
+| Build packages | `bb build [module]` |
+| Verify artifact contracts | `bb verify` |
+| Inspect the release plan | `bb release:plan` |
+
+Package selectors are directory names such as `collet-core`,
+`collet-action-http`, `collet-actions`, `collet-app`, and `collet-cli`.
+
+## Operating Rules
+
+- Preserve user-owned changes. Inspect a dirty file before editing it, and do
+  not revert, overwrite, or clean unrelated work.
+- Do not run destructive file or Git operations unless the user explicitly
+  requested the exact operation.
+- Keep one logical change per branch or worktree. Use the active worktree for
+  every command so REPL state, source paths, and Git state agree.
+- Keep runtime changes and package-specific tests/resources in the owning
+  package. Put reusable unpublished test helpers in `test-fixtures`.
+- Internal source dependencies stay as top-level `:local/root` entries. Do not
+  replace them with Maven versions or edit generated POMs.
+- Root build, CI, documentation, agent, and development files do not select a
+  package release. If a packaging change alters an artifact, change the owning
+  package metadata in the same release-producing commit.
+- Never run `bb release` unless the user explicitly requests publication.
+
+## Clojure and REPL Rules
+
+- Clojure work is REPL-first. Before editing any Clojure source, test, fixture,
+  or build namespace, attach to or start an nREPL from the active worktree.
+- Discover servers with `clj-nrepl-eval --discover-ports`. If the global client
+  is unavailable, run
+  `bb scripts/agent/nrepl-eval.bb --discover`.
+- If no suitable worktree REPL is running, start
+  `clojure -M:dev:nrepl` in a long-running terminal, then rediscover its port.
+- If a sandbox denies a loopback socket with `Operation not permitted`, rerun
+  the exact start or eval command through the environment's approval mechanism.
+  The repository fallback client cannot bypass OS or sandbox permissions.
+- Apply runtime and shared-fixture edits with
+  `clj-nrepl-eval -p <port> "(user/reload)"`. The fallback form is:
+
+  ```shell
+  bb scripts/agent/nrepl-eval.bb \
+    --port <port> \
+    --code "(user/reload)"
+  ```
+
+- The root reload scope is every existing `collet-*/src` directory plus
+  `test-fixtures/src`. Package tests and `build/src` remain authoritative
+  through their isolated CLI test commands.
+- Never use `:reload-all` or `tools.namespace/refresh-all`. They can re-evaluate
+  library protocols and orphan live instances.
+- Recreate pipelines, records, deftypes, protocol implementations, publishers,
+  and other stateful values after reload. Restart the JVM if a value is bound
+  to a stale class or protocol identity.
+- Keep evals small, deterministic, and bounded. Do not run destructive file,
+  Git, publication, or network actions through nREPL without explicit
+  authorization.
+- If startup, rediscovery, the fallback client, and required sandbox approval
+  all fail, report the REPL as a blocker instead of switching silently to a
+  CLI-only Clojure workflow.
+
+## REPL-First Code Discovery
+
+Use nREPL to inspect dependency and library APIs. Do not scrape source from
+`~/.m2`, Git dependency caches, JARs, or generated POMs when the namespace is
+available on the development classpath.
+
+```clojure
+(require '[some.library :as lib] :reload)
+(dir some.library)
+(doc lib/function)
+(source lib/function)
+(ns-publics 'some.library)
+```
+
+Repository source files may be read normally. Use `:reload` for manual
+namespace investigation so an earlier require does not hide recent edits.
+
+## Parenthesis Repair
+
+Do not manually repair unbalanced Clojure delimiters.
+
+```shell
+clj-paren-repair path/to/file.clj
+```
+
+Run the command from the repository root. File mode repairs delimiters and
+formats with cljfmt using this repository's `.cljfmt.edn`. It accepts multiple
+files when one edit broke more than one form.
+
+Use the tool only after a reader or delimiter failure, not as the routine
+formatter. Inspect the resulting diff, confirm the intended form structure,
+then rerun `(user/reload)` and the affected tests. If the command is missing or
+cannot repair the file, report the blocker rather than guessing.
+
+## Module Boundaries
+
+- `collet-core` owns the pipeline engine and built-in core actions.
+- Each `collet-action-*` package owns one optional integration. Add a direct
+  `:local/root` dependency only when that action genuinely uses another
+  workspace package.
+- `collet-actions` is the compatibility aggregate. It re-exports action
+  namespaces through dependencies and should not accumulate new runtime
+  implementation.
+- `collet-app` owns the JVM entrypoint, runtime configuration, metrics, and
+  deployable JAR/image inputs.
+- `collet-cli` owns the Babashka pod protocol and CLI archive.
+- `test-fixtures` is unpublished and reusable only by tests and development
+  tooling.
+- `build` owns package discovery, dependency ordering, artifact verification,
+  version planning, publication orchestration, and tags.
+
+When a package boundary, namespace, entrypoint, or exceptional output changes,
+update that package's `:collet/artifact` map and its verification coverage.
+
+## Validation Rules
+
+- Documentation-only changes: check referenced paths, commands, Markdown links,
+  and `git diff --check`.
+- Runtime Clojure changes: reload through nREPL, run
+  `bb test:module <module>`, then `bb test:unit`.
+- Test or build-tool Clojure changes: keep the required worktree REPL attached,
+  then run the owning isolated test command. The root reload path does not add
+  all package tests or build dependencies to one JVM.
+- Docker-, database-, LocalStack-, app-startup-, CLI-startup-, or image-related
+  changes: run `bb test:integration` in addition to unit tests.
+- Dependency, artifact, namespace, executable, or packaging changes: finish
+  with `bb verify` and `bb release:plan`.
+- Agent/REPL tooling changes: test non-interactive `:dev` loading, start a real
+  nREPL, evaluate through both clients, exercise documented error paths, and
+  verify parenthesis repair with a temporary malformed file.
+- Before reporting completion, review the full diff and rerun every command
+  that supports the final claims.
+
+## Release Rules
+
+- Kmono derives independent versions from landed conventional commits and
+  package tags, not branch names or a source version file.
+- `fix:` produces a patch, `feat:` a minor, and `type!:` or a
+  `BREAKING CHANGE:` footer a major version.
+- Documentation, tests, test resources, configs, and development files are
+  ignored for package selection. A runtime change without a release-producing
+  landed commit makes release planning fail.
+- `bb release:plan` is read-only and should be run before merge or publication.
+- `bb release` tests, verifies, builds, publishes Maven artifacts, and tags
+  packages. It is approval-gated and does not publish the CLI archive or Docker
+  image.
+
+## Task Router
+
+| Task | Read first |
+| --- | --- |
+| REPL or agent Clojure workflow | `docs/repl-workflow.md` |
+| Package/dependency change | `docs/development.md` |
+| Action behavior | `docs/actions.md` |
+| Selection DSL | `docs/select-syntax.md` |
+| Conditions | `docs/condition-syntax.md` |
+| Dependency loading | `docs/deps.md` |
+| Modular artifact compatibility | `docs/module-migration.md` |
+| Versioning or publication | `docs/releasing.md` |
+| Deployment image | `collet-app/deploy.md` |
+| Future architecture | `COLLET_NEXT.md` |
+
+## Reference Docs
+
+- `docs/repl-workflow.md` - mandatory agent REPL lifecycle and recovery.
+- `docs/development.md` - workspace commands, package changes, branches, and
+  Kmono version behavior.
+- `docs/module-migration.md` - module boundaries and compatibility.
+- `docs/releasing.md` - release planning, publication, and recovery.
+- `README.md` - pipeline, action, application, and module overview.

--- a/COLLET_NEXT.md
+++ b/COLLET_NEXT.md
@@ -123,7 +123,7 @@ Execution is **at least once**. Worker death, lease expiry, network partitions, 
 
 Datalevin stores coordination metadata, not workload payloads.
 
-The coordination baseline is [Datalevin 1.0.0](https://github.com/datalevin/datalevin/blob/1.0.0/CHANGELOG.md#100-2026-07-20), released on 2026-07-20. It requires Java 21, which already matches Collet. The release turns several former infrastructure assumptions into available platform capabilities, but it does not remove the need for Collet's own work, artifact, and reconciliation semantics:
+The coordination baseline is [Datalevin 1.0.0](https://github.com/datalevin/datalevin/blob/1.0.0/CHANGELOG.md#100-2026-07-20), released on 2026-07-20. It requires Java 25, which already matches Collet. The release turns several former infrastructure assumptions into available platform capabilities, but it does not remove the need for Collet's own work, artifact, and reconciliation semantics:
 
 | Datalevin 1.0 capability | Collet decision |
 |---|---|
@@ -373,7 +373,7 @@ deployment. Dependency order matters more than issue number:
 ```
 
 - [#43](https://github.com/velio-io/collet/issues/43) modernizes the build and separates optional action dependencies.
-- [#44](https://github.com/velio-io/collet/issues/44) separates immutable definitions from durable runs, introduces embedded Datalevin 1.x on the existing Java 21 baseline, and establishes versioned semantic task/action fingerprints with a conservative non-reusable fallback.
+- [#44](https://github.com/velio-io/collet/issues/44) separates immutable definitions from durable runs, introduces embedded Datalevin 1.x on the existing Java 25 baseline, and establishes versioned semantic task/action fingerprints with a conservative non-reusable fallback.
 - [#45](https://github.com/velio-io/collet/issues/45) selects the durable dataset format and task-local analytical integration using evidence.
 - [#46](https://github.com/velio-io/collet/issues/46) implements the selected nested and extended Arrow type boundary.
 - [#48](https://github.com/velio-io/collet/issues/48) establishes artifact, one-entry dataset snapshot, materialization, publication, and lineage identities for exact whole-task reuse.

--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ the CLI GitHub release and pushing the Docker image are later, explicit operatio
 from their respective package tags.
 
 ```shell
+clojure -M:dev:nrepl
 bb kmono query
 bb test:unit
 bb test:integration
@@ -579,11 +580,14 @@ bb release:plan
 bb release
 ```
 
-See [development](./docs/development.md), [module migration](./docs/module-migration.md),
-and [release](./docs/releasing.md) for prerequisites, the complete command contract,
-versioning, Kaven publication, fail-fast manual recovery after partial Maven publication, Docker tests,
-and compatibility guidance. `bb release` never uploads the CLI archive or a Docker
-image; those are explicit workflows from their independently versioned package tags.
+See [development](./docs/development.md), the agent
+[REPL workflow](./docs/repl-workflow.md),
+[module migration](./docs/module-migration.md), and
+[release](./docs/releasing.md) for prerequisites, the complete command contract,
+interactive reloads, parenthesis repair, versioning, Kaven publication, fail-fast
+manual recovery after partial Maven publication, Docker tests, and compatibility
+guidance. `bb release` never uploads the CLI archive or a Docker image; those are
+explicit workflows from their independently versioned package tags.
 
 ## License
 

--- a/build/test/collet/dev_tooling_test.clj
+++ b/build/test/collet/dev_tooling_test.clj
@@ -1,0 +1,238 @@
+(ns collet.dev-tooling-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.net InetAddress ServerSocket]
+   [java.nio.file Files]
+   [java.util.concurrent TimeUnit]))
+
+
+(def ^:private nrepl-client-script
+  (.getAbsolutePath (io/file "scripts/agent/nrepl-eval.bb")))
+
+(defn- root-deps []
+  (-> "deps.edn"
+      slurp
+      edn/read-string))
+
+
+(defn- reload-dirs []
+  (->> (.listFiles (io/file "."))
+       (filter #(.isDirectory %))
+       (filter #(str/starts-with? (.getName %) "collet-"))
+       (map #(io/file % "src"))
+       (filter #(.isDirectory %))
+       (map #(.getPath %))
+       sort
+       vec
+       (#(conj % "test-fixtures/src"))))
+
+
+(defn- run-nrepl-client
+  [& args]
+  (apply shell/sh "bb" nrepl-client-script args))
+
+
+(defn- run-nrepl-client-in
+  [dir & args]
+  (apply shell/sh
+         (concat ["bb" nrepl-client-script]
+                 args
+                 [:dir dir])))
+
+
+(defn- delete-tree
+  [root]
+  (when (.exists (io/file root))
+    (doseq [file (reverse (file-seq (io/file root)))]
+      (io/delete-file file true))))
+
+
+(defn- await-nrepl-port
+  [process dir]
+  (let [port-file (io/file dir ".nrepl-port")]
+    (loop [attempts 200]
+      (let [raw-port (when (.exists port-file)
+                       (str/trim (slurp port-file)))]
+        (cond
+          (and raw-port (re-matches #"\d+" raw-port))
+          (Integer/parseInt raw-port)
+
+          (not (.isAlive process))
+          (throw
+           (ex-info "Ephemeral nREPL exited before writing .nrepl-port"
+                    {:exit   (.exitValue process)
+                     :output (slurp (.getInputStream process))}))
+
+          (zero? attempts)
+          (throw (ex-info "Timed out starting ephemeral nREPL" {:dir dir}))
+
+          :else
+          (do
+            (Thread/sleep 50)
+            (recur (dec attempts))))))))
+
+
+(defn- with-ephemeral-nrepl
+  [f]
+  (let [dir     (str (Files/createTempDirectory
+                      "collet-dev-tooling-test-"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))
+        process (-> (ProcessBuilder.
+                     ^java.util.List
+                     ["clojure"
+                      "-Sdeps"
+                      "{:deps {nrepl/nrepl {:mvn/version \"1.7.0\"}}}"
+                      "-M" "-m" "nrepl.cmdline"
+                      "--bind" "127.0.0.1"])
+                    (.directory (io/file dir))
+                    (.redirectErrorStream true)
+                    (.start))]
+    (try
+      (f {:dir dir :port (await-nrepl-port process dir)})
+      (finally
+        (.destroy process)
+        (when-not (.waitFor process 5 TimeUnit/SECONDS)
+          (.destroyForcibly process)
+          (.waitFor process 5 TimeUnit/SECONDS))
+        (delete-tree dir)))))
+
+
+(defn- unused-loopback-port
+  []
+  (with-open [socket (ServerSocket. 0 1
+                                    (InetAddress/getByName "127.0.0.1"))]
+    (.getLocalPort socket)))
+
+
+(deftest nrepl-port-waiter-rejects-transient-empty-content
+  (let [dir       (str (Files/createTempDirectory
+                        "collet-port-waiter-test-"
+                        (make-array java.nio.file.attribute.FileAttribute 0)))
+        port-file (io/file dir ".nrepl-port")
+        process   (-> (ProcessBuilder.
+                       ^java.util.List ["sh" "-c" "sleep 5"])
+                      (.start))
+        writer    (future
+                    (Thread/sleep 100)
+                    (spit port-file "54321"))]
+    (try
+      (spit port-file "")
+      (is (= 54321 (await-nrepl-port process dir)))
+      (finally
+        (deref writer 1000 nil)
+        (.destroyForcibly process)
+        (.waitFor process 5 TimeUnit/SECONDS)
+        (delete-tree dir)))))
+
+
+(deftest root-repl-aliases-are-reproducible
+  (let [deps (root-deps)]
+    (testing "development dependencies and sources"
+      (is (= ["dev"] (get-in deps [:aliases :dev :extra-paths])))
+      (is (= {:local/root "test-fixtures"}
+             (get-in deps
+                     [:aliases :dev :extra-deps
+                      'io.velio/collet-test-fixtures])))
+      (is (= "1.0.0"
+             (get-in deps
+                     [:aliases :dev :extra-deps
+                      'io.github.tonsky/clj-reload :mvn/version]))))
+    (testing "loopback-only nREPL startup"
+      (is (= "1.7.0"
+             (get-in deps
+                     [:aliases :nrepl :extra-deps
+                      'nrepl/nrepl :mvn/version])))
+      (is (= ["-m" "nrepl.cmdline"
+              "--interactive" "--color" "--bind" "127.0.0.1"]
+             (get-in deps [:aliases :nrepl :main-opts]))))))
+
+
+(deftest root-dev-namespace-exposes-project-scoped-reload
+  (let [expected    (reload-dirs)
+        user-source (slurp "dev/user.clj")
+        code        (str "(assert (= " (pr-str expected) " user/reload-dirs)) "
+                      "(assert (= '([]) (:arglists (meta #'user/reload)))) "
+                      "(println \"dev-repl-contract-ok\")")
+        {:keys [exit out err]} (shell/sh "clojure" "-M:dev" "-e" code)]
+    (is (zero? exit) (str out err))
+    (is (str/includes? out "dev-repl-contract-ok") out)
+    (is (str/includes? user-source ":no-reload '#{user}") user-source)
+    (is (not (re-find #"\[collet\." user-source)) user-source)))
+
+
+(deftest fallback-nrepl-client-has-a-stable-cli
+  (testing "help"
+    (let [{:keys [exit out err]} (run-nrepl-client "--help")]
+      (is (zero? exit) err)
+      (is (str/includes? out "nrepl-eval.bb --code <CODE>") out)))
+  (testing "port discovery"
+    (let [{:keys [exit out err]} (run-nrepl-client "--discover")]
+      (is (zero? exit) err)
+      (is (str/includes? out ".nrepl-port files:") out)
+      (is (str/includes? out "java TCP listeners:") out)))
+  (testing "evaluation and port-file discovery"
+    (with-ephemeral-nrepl
+      (fn [{:keys [dir port]}]
+        (let [{:keys [exit out err]}
+              (run-nrepl-client "--port" (str port) "--code" "(+ 1 2)")]
+          (is (zero? exit) err)
+          (is (= "3" (str/trim out)) out))
+        (let [{:keys [exit out err]}
+              (run-nrepl-client-in dir "--code" "(* 6 7)")]
+          (is (zero? exit) err)
+          (is (= "42" (str/trim out)) out))
+        (let [{:keys [exit err]} (shell/sh "git" "init" :dir dir)
+              nested-dir         (io/file dir "nested")]
+          (is (zero? exit) err)
+          (is (.mkdir nested-dir))
+          (let [{:keys [exit out err]}
+                (run-nrepl-client-in
+                 (str nested-dir)
+                 "--code" "(+ 20 22)")]
+            (is (zero? exit) err)
+            (is (= "42" (str/trim out)) out)))
+        (let [{:keys [exit err]}
+              (run-nrepl-client
+               "--port" (str port)
+               "--code" "(throw (ex-info \"expected\" {}))")]
+          (is (= 1 exit) err)
+          (is (str/includes? err "ex:") err))
+        (let [started-at (System/nanoTime)
+              {:keys [exit err]}
+              (run-nrepl-client
+               "--port" (str port)
+               "--timeout" "1"
+               "--code"
+               (str "(do (Thread/sleep 800) (println \"progress\") "
+                    "(Thread/sleep 800) :done)"))
+              elapsed-ms (/ (- (System/nanoTime) started-at) 1000000.0)]
+          (is (= 4 exit) err)
+          (is (str/includes? err "timed out") err)
+          (is (< elapsed-ms 1500)
+              (str "client exceeded its overall deadline: "
+                   elapsed-ms "ms"))))))
+  (testing "connection errors"
+    (let [{:keys [exit err]}
+          (run-nrepl-client
+           "--port" (str (unused-loopback-port))
+           "--code" "(+ 1 2)")]
+      (is (= 3 exit) err)
+      (is (str/includes? err "cannot connect") err)))
+  (testing "usage errors"
+    (is (= 64 (:exit (run-nrepl-client))))
+    (is (= 64 (:exit (run-nrepl-client
+                      "--port" "0"
+                      "--code" "(+ 1 2)"))))
+    (is (= 64 (:exit (run-nrepl-client
+                      "--port" "1"
+                      "--timeout" "0"
+                      "--code" "(+ 1 2)"))))
+    (is (= 64 (:exit (run-nrepl-client
+                      "--port" "1"
+                      "--timeout" "-1"
+                      "--code" "(+ 1 2)"))))))

--- a/deps.edn
+++ b/deps.edn
@@ -26,24 +26,33 @@
              "--enable-native-access=ALL-UNNAMED"]}
 
  :paths []
- :deps  {io.velio/collet-core          {:local/root "collet-core"}
-         io.velio/collet-action-http   {:local/root "collet-action-http"}
-         io.velio/collet-action-file   {:local/root "collet-action-file"}
-         io.velio/collet-action-odata  {:local/root "collet-action-odata"}
-         io.velio/collet-action-jdbc   {:local/root "collet-action-jdbc"}
-         io.velio/collet-action-s3     {:local/root "collet-action-s3"}
-         io.velio/collet-action-queue  {:local/root "collet-action-queue"}
-         io.velio/collet-action-jslt   {:local/root "collet-action-jslt"}
-         io.velio/collet-action-llm    {:local/root "collet-action-llm"}
-         io.velio/collet-action-vega   {:local/root "collet-action-vega"}
-         io.velio/collet-action-lucene {:local/root "collet-action-lucene"}
-         io.velio/collet-actions       {:local/root "collet-actions"}
-         io.velio/collet-app           {:local/root "collet-app"}
-         io.velio/collet-cli           {:local/root "collet-cli"}}
+
+ :deps
+ {io.velio/collet-core          {:local/root "collet-core"}
+  io.velio/collet-action-http   {:local/root "collet-action-http"}
+  io.velio/collet-action-file   {:local/root "collet-action-file"}
+  io.velio/collet-action-odata  {:local/root "collet-action-odata"}
+  io.velio/collet-action-jdbc   {:local/root "collet-action-jdbc"}
+  io.velio/collet-action-s3     {:local/root "collet-action-s3"}
+  io.velio/collet-action-queue  {:local/root "collet-action-queue"}
+  io.velio/collet-action-jslt   {:local/root "collet-action-jslt"}
+  io.velio/collet-action-llm    {:local/root "collet-action-llm"}
+  io.velio/collet-action-vega   {:local/root "collet-action-vega"}
+  io.velio/collet-action-lucene {:local/root "collet-action-lucene"}
+  io.velio/collet-actions       {:local/root "collet-actions"}
+  io.velio/collet-app           {:local/root "collet-app"}
+  io.velio/collet-cli           {:local/root "collet-cli"}}
+
  :aliases
  {:dev
-  {:extra-deps {io.velio/collet-test-fixtures
-                {:local/root "test-fixtures"}}}
+  {:extra-paths ["dev"]
+   :extra-deps  {io.velio/collet-test-fixtures {:local/root "test-fixtures"}
+                 io.github.tonsky/clj-reload   {:mvn/version "1.0.0"}}}
+
+  :nrepl
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--interactive" "--color" "--bind" "127.0.0.1"]}
 
   :kmono
   {:extra-deps {com.kepler16/kmono-cli {:mvn/version "4.12.3"}}
@@ -58,12 +67,11 @@
    :ns-default collet.build}
 
   :build-test
-  {:deps      {com.kepler16/kmono            {:mvn/version "4.12.3"}
-               com.kepler16/kaven            {:mvn/version "1.0.0"}
-               org.clojure/data.xml          {:mvn/version "0.2.0-alpha11"}
-               io.github.clojure/tools.build {:mvn/version "0.10.14"}
-               io.github.cognitect-labs/test-runner
-               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+  {:deps      {com.kepler16/kmono                   {:mvn/version "4.12.3"}
+               com.kepler16/kaven                   {:mvn/version "1.0.0"}
+               org.clojure/data.xml                 {:mvn/version "0.2.0-alpha11"}
+               io.github.clojure/tools.build        {:mvn/version "0.10.14"}
+               io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :paths     ["build/src" "build/test"]
    :exec-fn   cognitect.test-runner.api/test
    :exec-args {:dirs ["build/test"]}}}}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,27 @@
+(ns user
+  (:require
+   [clj-reload.core :as reload]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+
+(def reload-dirs
+  (->> (.listFiles (io/file "."))
+       (filter #(.isDirectory %))
+       (filter #(str/starts-with? (.getName %) "collet-"))
+       (map #(io/file % "src"))
+       (filter #(.isDirectory %))
+       (map #(.getPath %))
+       sort
+       vec
+       (#(conj % "test-fixtures/src"))))
+
+
+(reload/init
+ {:dirs      reload-dirs
+  :no-reload '#{user}})
+
+
+(defn reload
+  []
+  (reload/reload))

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,9 @@ artifact contract in its own `deps.edn` under `:collet/artifact`.
   version, which is a compatibility break from previous releases.
 - Clojure CLI.
 - Babashka.
+- `clj-paren-repair` for the agent Clojure workflow.
+- `clj-nrepl-eval` is the preferred eval client; the repository includes a
+  Babashka fallback when it is unavailable.
 - Docker for PostgreSQL, MySQL, LocalStack, application/CLI startup, and image
   integration tests.
 
@@ -37,6 +40,7 @@ Run build, workspace, verification, and release commands from the repository roo
 
 | Command | Behavior |
 |---|---|
+| `clojure -M:dev:nrepl` | Starts a loopback-only worktree nREPL with project-scoped reload tooling. |
 | `bb kmono query` | Prints Kmono's resolved package graph. Additional Kmono query arguments may follow. |
 | `bb test:unit` | Runs build-tool tests once and every package in a separate JVM, excluding `^:integration` tests; Docker is not required. |
 | `bb test:integration` | Builds app/CLI outputs, then runs only integration tests in integration-bearing packages; Docker is required. |
@@ -52,6 +56,11 @@ Package selectors are directory names such as `collet-core`,
 `collet-action-http`, `collet-actions`, `collet-app`, and `collet-cli`. Package-local
 `clojure -M:test` remains useful while developing one module; the table above is the
 supported repository orchestration contract.
+
+Agent-driven Clojure work is REPL-first. See the
+[REPL workflow](./repl-workflow.md) for worktree isolation, port discovery,
+evaluation clients, project-scoped `(user/reload)`, parenthesis repair, and
+sandbox recovery.
 
 ## Build outputs
 

--- a/docs/repl-workflow.md
+++ b/docs/repl-workflow.md
@@ -1,0 +1,217 @@
+# REPL Workflow
+
+Collet uses a REPL-first Clojure workflow. Agents must attach to or start an
+nREPL from the active worktree before editing Clojure source, tests, fixtures,
+or build tooling. Each worktree needs its own JVM so reloads and evaluations use
+the files being edited.
+
+## Prerequisites
+
+- JDK 25 or newer.
+- Clojure CLI.
+- Babashka.
+- `clj-nrepl-eval` on `PATH` for the preferred eval client.
+- `clj-paren-repair` on `PATH` for delimiter recovery.
+
+The repository includes `scripts/agent/nrepl-eval.bb` as an eval fallback.
+Parenthesis repair remains an explicit local development prerequisite.
+
+## Start nREPL
+
+Run from the active worktree root:
+
+```shell
+clojure -M:dev:nrepl
+```
+
+The server binds only to `127.0.0.1`, chooses a free port, and writes that port
+to `.nrepl-port`. The file is ignored by Git and removed when the JVM shuts down
+normally. Keep this command running in a long-lived terminal.
+
+## Discover a Running Server
+
+Prefer the installed client:
+
+```shell
+clj-nrepl-eval --discover-ports
+```
+
+Use the repository fallback when the global client is unavailable:
+
+```shell
+bb scripts/agent/nrepl-eval.bb --discover
+```
+
+The fallback checks `.nrepl-port` in the current directory and Git worktree
+root, then reports listening Java endpoints as diagnostic candidates. Always
+choose the port belonging to the active worktree.
+
+## Evaluate Code
+
+With the preferred client:
+
+```shell
+clj-nrepl-eval -p <port> "(+ 1 2)"
+clj-nrepl-eval -p <port> --timeout 5000 "(+ 1 2)"
+```
+
+With the repository fallback:
+
+```shell
+bb scripts/agent/nrepl-eval.bb \
+  --port <port> \
+  --code "(+ 1 2)"
+
+bb scripts/agent/nrepl-eval.bb \
+  --port <port> \
+  --timeout 5 \
+  --code "(+ 1 2)"
+```
+
+The global client timeout is expressed in milliseconds; the fallback timeout is
+expressed in seconds. Don't overuse timeouts, try first without timeout.
+Both clients reuse the running JVM, so loaded namespaces
+and state persist between evaluations.
+
+The fallback exits with `0` on success, `1` for an nREPL evaluation error, `3`
+for a connection failure, `4` for a timeout, and `64` for invalid usage.
+
+## Reload Changed Code
+
+The primary cycle is:
+
+```text
+attach or start -> edit -> reload -> validate
+```
+
+After changing production or shared-fixture code:
+
+```shell
+clj-nrepl-eval -p <port> "(user/reload)"
+```
+
+Fallback:
+
+```shell
+bb scripts/agent/nrepl-eval.bb \
+  --port <port> \
+  --code "(user/reload)"
+```
+
+`dev/user.clj` configures clj-reload for every existing `collet-*/src`
+directory plus `test-fixtures/src`. `user` is excluded so the REPL entrypoint
+and reload function remain stable. The reload result reports the namespaces
+that were unloaded and loaded.
+
+Never use `:reload-all` or `tools.namespace/refresh-all`. Those operations can
+walk into dependencies, recreate protocol identities, and leave existing
+records or deftypes implementing an obsolete protocol.
+
+Package tests and `build/src` deliberately remain outside the root reload
+scope. A worktree REPL is still required before editing them, but their
+executable validation is the isolated package or build test command:
+
+```shell
+bb test:module <module>
+clojure -T:build-test
+```
+
+## Stateful Values
+
+Reload replaces namespace vars and may recreate records, deftypes, protocols,
+and multimethod definitions. Do not rely on live pipelines, task results,
+publishers, or protocol implementations created before a reload.
+
+After `(user/reload)`:
+
+1. Re-evaluate the form that constructs the pipeline or runtime value.
+2. Repeat the focused behavior check.
+3. Restart the nREPL JVM if dispatch reports an old class or protocol identity.
+
+Collet does not automatically stop or restart pipelines from `user/reload`.
+Automatic lifecycle management would be unsafe because the REPL cannot infer
+which user-created runtime values are disposable.
+
+## Dependency and Library Discovery
+
+Inspect dependency APIs through the running REPL instead of scraping Maven
+caches, Git dependency checkouts, JARs, or generated POMs:
+
+```clojure
+(require '[some.library :as lib] :reload)
+(dir some.library)
+(doc lib/function)
+(source lib/function)
+(ns-publics 'some.library)
+```
+
+Repository source can be read directly. Use `:reload` during manual namespace
+investigation so a cached require does not hide recent edits.
+
+## Parenthesis Repair
+
+When reload reports an unmatched, unexpected, or EOF delimiter error, do not
+balance the form manually. From the repository root run:
+
+```shell
+clj-paren-repair path/to/file.clj
+```
+
+Multiple files are supported:
+
+```shell
+clj-paren-repair path/to/first.clj path/to/second.clj
+```
+
+In file mode the tool repairs delimiters and invokes cljfmt in the current
+project environment, so Collet's `.cljfmt.edn` is applied. Use it only for
+delimiter recovery, not routine formatting.
+
+After repair:
+
+1. Inspect `git diff -- path/to/file.clj`.
+2. Confirm the repaired form still expresses the intended behavior.
+3. Evaluate `(user/reload)` again.
+4. Run the affected package or build tests.
+
+If `clj-paren-repair` is missing or returns a failure, stop and report the
+blocker rather than guessing at the delimiter structure.
+
+## Sandbox and Connection Recovery
+
+Some agent sandboxes deny loopback sockets or process inspection. A failure
+such as `java.net.SocketException: Operation not permitted` is an environment
+restriction, not evidence that nREPL failed to start.
+
+Use this recovery order:
+
+1. Confirm the command is running from the active worktree.
+2. Rediscover ports with the preferred client.
+3. Try the repository fallback discovery and eval commands.
+4. Rerun the exact socket command through the environment's approval mechanism.
+5. If connection is still unavailable, report a blocker instead of continuing
+   with a CLI-only Clojure workflow.
+
+## Troubleshooting
+
+| Problem | Resolution |
+| --- | --- |
+| No `.nrepl-port` | Start `clojure -M:dev:nrepl` from the worktree root. |
+| Stale or refused port | Stop the stale JVM if owned by this worktree, start a new nREPL, and rediscover. |
+| `Operation not permitted` | Request the environment's loopback/process approval and rerun the command. |
+| Eval client missing | Use `bb scripts/agent/nrepl-eval.bb`. |
+| Eval times out | Reduce the form, set a bounded timeout, and check for blocking work in the JVM. |
+| Reload reports a delimiter error | Run `clj-paren-repair` on the reported file, inspect the diff, and reload again. |
+| Reload reports a stale protocol/class | Recreate affected values; restart the JVM if stale identity remains. |
+| Test namespace changed | Run its package/build CLI test; tests are not added to the root REPL classpath. |
+
+## Safety
+
+- Keep evals small and deterministic.
+- Do not run file deletion, Git mutation, publication, or external network
+  actions through nREPL without explicit authorization.
+- Do not treat a successful reload as test coverage. Run the owning tests.
+- Do not run `bb release` as part of development or REPL validation.
+
+See [development](./development.md) for the complete command contract and
+[releasing](./releasing.md) for approval-gated publication.

--- a/scripts/agent/nrepl-eval.bb
+++ b/scripts/agent/nrepl-eval.bb
@@ -1,0 +1,292 @@
+#!/usr/bin/env bb
+;; Minimal nREPL eval client for Collet agents.
+;;
+;; Usage:
+;;   nrepl-eval.bb --code <CODE> [--port <INT>] [--timeout <SECONDS>]
+;;   nrepl-eval.bb --discover
+;;   nrepl-eval.bb --help
+;;
+;; Primary tool is clj-nrepl-eval; this is the durable repository fallback
+;; when it is not installed on PATH.
+;;
+;; Exit codes: 0 ok, 1 REPL :ex, 3 connect error, 4 timeout, 64 bad args.
+
+(require '[babashka.cli :as cli]
+         '[babashka.process :as proc]
+         '[bencode.core :as bencode])
+
+(import '[java.io BufferedOutputStream IOException PushbackInputStream]
+        '[java.net ConnectException Socket SocketTimeoutException])
+
+
+(def cli-spec
+  {:spec     {:code     {:desc "Clojure form to eval"}
+              :port     {:desc "nREPL port" :coerce :int}
+              :timeout  {:desc "Seconds to wait for completion"
+                         :coerce :int
+                         :default 30}
+              :discover {:desc "Print port candidates and exit"
+                         :coerce :boolean}
+              :help     {:desc "Show usage" :coerce :boolean :alias :h}}
+   :restrict [:code :port :timeout :discover :help]})
+
+
+(def usage
+  (str "Usage:\n"
+       "  nrepl-eval.bb --code <CODE> [--port <INT>] [--timeout <SECONDS>]\n"
+       "  nrepl-eval.bb --discover\n"
+       "  nrepl-eval.bb --help\n\n"
+       "Examples:\n"
+       "  bb scripts/agent/nrepl-eval.bb --port 56124 --code \"(+ 1 2)\"\n"
+       "  bb scripts/agent/nrepl-eval.bb --discover\n\n"
+       "Exit codes:\n"
+       "  0 success\n"
+       "  1 nREPL evaluation error\n"
+       "  3 connection error\n"
+       "  4 timeout\n"
+       "  64 usage error\n\n"
+       "Primary tool is clj-nrepl-eval; this is the durable fallback."))
+
+
+(defn die
+  [code & message]
+  (binding [*out* *err*]
+    (apply println message))
+  (System/exit code))
+
+
+(defn bytes->strings
+  [value]
+  (cond
+    (bytes? value)      (String. ^bytes value "UTF-8")
+    (sequential? value) (mapv bytes->strings value)
+    (map? value)        (into {}
+                              (for [[key item] value]
+                                [(bytes->strings key)
+                                 (bytes->strings item)]))
+    :else               value))
+
+
+(defn read-port-file
+  [path]
+  (when (and path (.exists (io/file path)))
+    (try
+      (let [raw (str/trim (slurp path))]
+        (when (re-matches #"\d+" raw)
+          (Integer/parseInt raw)))
+      (catch Exception _
+        nil))))
+
+
+(defn git-toplevel
+  [cwd]
+  (try
+    (let [{:keys [exit out]}
+          (proc/sh {:dir cwd :err :string}
+                   "git" "rev-parse" "--show-toplevel")]
+      (when (zero? exit)
+        (str/trim out)))
+    (catch Exception _
+      nil)))
+
+
+(defn java-listeners
+  []
+  (try
+    (let [{:keys [exit out]}
+          (proc/sh
+           {:err :string}
+           "sh" "-c"
+           (str "lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null "
+                "| awk '/^java/ { print $9 }'"))]
+      (when (zero? exit)
+        (->> (str/split-lines out)
+             (map str/trim)
+             (remove str/blank?)
+             distinct
+             sort)))
+    (catch Exception _
+      nil)))
+
+
+(defn discover-candidates
+  []
+  (let [cwd       (System/getProperty "user.dir")
+        cwd-file  (str cwd "/.nrepl-port")
+        root      (git-toplevel cwd)
+        root-file (when root (str root "/.nrepl-port"))
+        cwd-port  (read-port-file cwd-file)
+        root-port (when (and root-file (not= root-file cwd-file))
+                    (read-port-file root-file))]
+    {:cwd-file   cwd-file
+     :cwd-port   cwd-port
+     :root-file  root-file
+     :root-port  root-port
+     :java-listeners (java-listeners)}))
+
+
+(defn pick-port
+  []
+  (let [{:keys [cwd-port root-port]} (discover-candidates)]
+    (or cwd-port root-port)))
+
+
+(defn remaining-timeout-ms
+  [deadline-ns]
+  (let [remaining-ns (- deadline-ns (System/nanoTime))]
+    (when-not (pos? remaining-ns)
+      (die 4 "nrepl-eval: timed out waiting for response"))
+    (-> (+ remaining-ns 999999)
+        (quot 1000000)
+        (max 1)
+        (min Integer/MAX_VALUE)
+        int)))
+
+
+(defn open-socket
+  [port deadline-ns]
+  (when (or (not (integer? port)) (< port 1) (> port 65535))
+    (die 64 (str "nrepl-eval: port out of range (1-65535): " port)))
+  (try
+    (doto (Socket.)
+      (.connect (java.net.InetSocketAddress. "127.0.0.1" (int port))
+                (remaining-timeout-ms deadline-ns)))
+    (catch ConnectException error
+      (die 3 (str "nrepl-eval: cannot connect to 127.0.0.1:"
+                  port " - " (.getMessage error))))
+    (catch SocketTimeoutException _
+      (die 3 (str "nrepl-eval: connect timeout to 127.0.0.1:" port)))
+    (catch IOException error
+      (die 3 (str "nrepl-eval: I/O error on 127.0.0.1:"
+                  port " - " (.getMessage error))))))
+
+
+(defn send!
+  [out message]
+  (bencode/write-bencode out message)
+  (.flush ^java.io.OutputStream out))
+
+
+(defn read-until-done
+  [socket in deadline-ns]
+  (loop [acc {:value [] :out [] :err [] :ex nil}]
+    (.setSoTimeout socket (remaining-timeout-ms deadline-ns))
+    (let [raw (try
+                (bencode/read-bencode in)
+                (catch SocketTimeoutException _
+                  ::timeout))]
+      (cond
+        (= raw ::timeout)
+        (die 4 "nrepl-eval: timed out waiting for response")
+
+        (nil? raw)
+        (die 1 "nrepl-eval: nREPL closed connection before :done")
+
+        :else
+        (let [message (bytes->strings raw)
+              status  (set (get message "status"))
+              acc'    (cond-> acc
+                        (get message "value")
+                        (update :value conj (get message "value"))
+
+                        (get message "out")
+                        (update :out conj (get message "out"))
+
+                        (get message "err")
+                        (update :err conj (get message "err"))
+
+                        (get message "ex")
+                        (assoc :ex (get message "ex")))]
+          (if (contains? status "done")
+            acc'
+            (recur acc')))))))
+
+
+(defn eval-code
+  [port code timeout-seconds]
+  (when (or (not (integer? timeout-seconds))
+            (not (pos? timeout-seconds)))
+    (die 64
+         (str "nrepl-eval: timeout must be a positive number of seconds: "
+              timeout-seconds)))
+  (when (> timeout-seconds 2147483)
+    (die 64
+         (str "nrepl-eval: timeout exceeds the supported maximum: "
+              timeout-seconds)))
+  (let [deadline (+ (System/nanoTime)
+                    (* 1000000000 (long timeout-seconds)))
+        socket   (open-socket port deadline)
+        out        (BufferedOutputStream. (.getOutputStream socket))
+        in         (PushbackInputStream. (.getInputStream socket))]
+    (send! out {"op" "eval" "code" code})
+    (let [{:keys [value out err ex]} (read-until-done socket in deadline)]
+      (when (seq out)
+        (print (apply str out))
+        (flush))
+      (when (seq err)
+        (binding [*out* *err*]
+          (print (apply str err))
+          (flush)))
+      (when ex
+        (binding [*out* *err*]
+          (println (str "ex: " ex))))
+      (doseq [item value]
+        (println item))
+      (System/exit (if ex 1 0)))))
+
+
+(defn print-discovery
+  []
+  (let [{:keys [cwd-file cwd-port root-file root-port java-listeners]}
+        (discover-candidates)]
+    (println ".nrepl-port files:")
+    (if (or cwd-port root-port)
+      (do
+        (when cwd-port
+          (println " " cwd-file "->" cwd-port))
+        (when root-port
+          (println " " root-file "->" root-port)))
+      (println "  none"))
+    (println "java TCP listeners:")
+    (if (seq java-listeners)
+      (doseq [endpoint java-listeners]
+        (println " " endpoint))
+      (println "  none"))
+    (System/exit 0)))
+
+
+(defn -main
+  [& argv]
+  (let [{:keys [code port timeout discover help]}
+        (try
+          (cli/parse-opts argv cli-spec)
+          (catch Exception error
+            (binding [*out* *err*]
+              (println "nrepl-eval:" (.getMessage error))
+              (println usage))
+            (System/exit 64)))]
+    (cond
+      help
+      (do
+        (println usage)
+        (System/exit 0))
+
+      discover
+      (print-discovery)
+
+      (nil? code)
+      (do
+        (binding [*out* *err*]
+          (println "nrepl-eval: --code is required")
+          (println usage))
+        (System/exit 64))
+
+      :else
+      (let [selected-port (or port (pick-port))]
+        (when (nil? selected-port)
+          (die 64
+               "nrepl-eval: specify --port or run from a worktree with .nrepl-port"))
+        (eval-code selected-port code (or timeout 30))))))
+
+
+(apply -main *command-line-args*)


### PR DESCRIPTION
## Summary

- add a loopback-only root nREPL with `clj-reload` and project-scoped `user/reload`
- add a checked-in Babashka nREPL evaluation fallback with bounded deadlines, worktree port discovery, and stable exit codes
- add comprehensive `AGENTS.md` and REPL workflow documentation, including mandatory `clj-paren-repair` handling
- add persistent build-tool tests for aliases, reload scope, evaluation, discovery, errors, timeouts, and startup races

## Why

Collet did not have repository-level agent guidance or a durable REPL workflow. Agents need a worktree-specific JVM, safe project-only reloads, a fallback when the machine-global evaluator is unavailable, and an explicit delimiter-repair policy.

## Developer impact

The canonical workflow is now:

```shell
clojure -M:dev:nrepl
clj-nrepl-eval --discover-ports
clj-nrepl-eval -p <port> "(user/reload)"
```

The repository fallback is available through `bb scripts/agent/nrepl-eval.bb`. Package tests and release interfaces remain unchanged.

## Reliability

Final verification exposed a race where nREPL could create `.nrepl-port` before writing its contents. The test waiter now polls until the file contains a complete numeric port, with a deterministic regression test covering the transient empty-file state.

## Validation

- `bb test`
- `bb verify`
- `bb release:plan`
- targeted agent-tooling tests repeated five times
- `clj-kondo --lint dev/user.clj build/test/collet/dev_tooling_test.clj scripts/agent/nrepl-eval.bb`
- staged diff and whitespace checks

`bb release:plan` still shows the pre-existing 0.2.9 plan from `main`; this development/tooling commit introduces no package release. `bb release` was not run.
