### PR TITLE
Issue #45: accept Parquet artifact decision

### DIFF
--- a/COLLET_NEXT.md
+++ b/COLLET_NEXT.md
@@ -212,8 +212,8 @@ The foundation snapshot initially contains one logical entry rather than exposin
 
 The snapshot ID hashes a versioned canonical logical manifest. It includes logical entry keys, content keys, schema/format identity, and required logical counts; it excludes storage URI, physical artifact reference, run/attempt identity, timestamps, and caller-provided map or entry order. The artifact reference is retained only to resolve the content. This lets the same logical dataset keep its identity when content is copied between local and object storage.
 
-The measured #45 decision provisionally recommends **Parquet plus DuckDB** for
-durable artifacts, pending review of
+The accepted #45 decision selects **Parquet plus DuckDB** for Collet-owned
+durable artifacts; see
 [`ADR 0045`](docs/adr/0045-dataset-artifact-spike.md). Native Ubuntu Gate 1
 proved that aligned Lance works under JDK 25, including version-pinned reopen,
 pre-commit recovery, LocalStack, and offline deployment. In the one-GiB Gate 2
@@ -222,12 +222,14 @@ process-cold peak RSS and changed about 2.13 GB for both add and replace versus
 18.4/18.8 MB Parquet replacements. Those results fail the approved 1.25x RSS
 and 0.75x amplification rules.
 
-- **Parquet plus DuckDB** is the measured recommendation. Reads use the artifact
+- **Parquet plus DuckDB** is the selected internal format. Reads use the artifact
   schema to restore `FLOAT[n]`, because the physical Parquet scan exposes
   `FLOAT[]`; benchmark writes use bounded 4,096-row groups.
 - **Lance** is technically viable on the required native platforms, but its
-  helper/native operational surface is not justified by this workload's RSS
-  and column-evolution evidence.
+  helper/native operational surface is not justified for internal immutable
+  artifacts by this workload's RSS and column-evolution evidence. It remains an
+  optional destination candidate in
+  [#62](https://github.com/velio-io/collet/issues/62).
 - **Arrow IPC** remains the default core streaming/interchange path; temporary
   IPC files are not a complete artifact system.
 - **DuckTape** may be an optional tech.ml.dataset view, but never the artifact
@@ -389,7 +391,7 @@ deployment. Dependency order matters more than issue number:
 
 - [#43](https://github.com/velio-io/collet/issues/43) modernizes the build and separates optional action dependencies.
 - [#44](https://github.com/velio-io/collet/issues/44) separates immutable definitions from durable runs, introduces embedded Datalevin 1.x on the existing Java 25 baseline, and establishes versioned semantic task/action fingerprints with a conservative non-reusable fallback.
-- [#45](https://github.com/velio-io/collet/issues/45) provisionally recommends Parquet plus DuckDB from aligned native Linux evidence; ADR 0045 remains pending review before the format is accepted.
+- [#45](https://github.com/velio-io/collet/issues/45) selected Parquet plus DuckDB for Collet-owned durable artifacts from aligned native Linux evidence.
 - [#46](https://github.com/velio-io/collet/issues/46) implements the selected nested and extended Arrow type boundary.
 - [#48](https://github.com/velio-io/collet/issues/48) establishes artifact, one-entry dataset snapshot, materialization, publication, and lineage identities for exact whole-task reuse.
 - [#47](https://github.com/velio-io/collet/issues/47) consumes #48 to add task-local DuckDB SQL; it is not a prerequisite for the artifact store.
@@ -400,6 +402,11 @@ deployment. Dependency order matters more than issue number:
 - [#53](https://github.com/velio-io/collet/issues/53) reconstructs derived state and safely adopts verified orphan artifacts.
 - [#54](https://github.com/velio-io/collet/issues/54) defines bounded, vendor-neutral execution telemetry for ABEL and other backends.
 - [#55](https://github.com/velio-io/collet/issues/55) decides the trust and process boundary for SCI, GraalVM, Python, and custom code.
+
+Optional post-foundation integration
+[#62](https://github.com/velio-io/collet/issues/62) keeps Lance outside the
+internal artifact path and tracks it as a versioned destination. It does not
+block the foundation graph or reopen #45.
 
 ## Foundation gaps not yet scheduled
 

--- a/COLLET_NEXT.md
+++ b/COLLET_NEXT.md
@@ -182,7 +182,7 @@ A large task output is published as a logical artifact dataset. The dataset may 
 ```clojure
 {:artifact/id          #uuid "..."
  :artifact/uri         "s3://collet-artifacts/runs/.../output"
- :artifact/format      :format/to-be-selected
+ :artifact/format      :format/parquet
  :artifact/version     7
  :artifact/schema      {:name :normalized-profile :version 3}
  :artifact/content-key "sha256:..."
@@ -206,24 +206,28 @@ The foundation snapshot initially contains one logical entry rather than exposin
  :snapshot/entries [{:entry/key          :whole-task
                      :entry/artifact-ref [:artifact/id artifact-id]
                      :entry/content-key  "sha256:..."
-                     :entry/format       :format/to-be-selected
+                     :entry/format       :format/parquet
                      :entry/records      58219}]}
 ```
 
 The snapshot ID hashes a versioned canonical logical manifest. It includes logical entry keys, content keys, schema/format identity, and required logical counts; it excludes storage URI, physical artifact reference, run/attempt identity, timestamps, and caller-provided map or entry order. The artifact reference is retained only to resolve the content. This lets the same logical dataset keep its identity when content is copied between local and object storage.
 
-The durable format remains unresolved while the corrected #45 spike awaits its
-native Linux AMD64 gate and benchmark. The earlier Parquet decision was
-withdrawn because it mixed Lance's declared Arrow 18.3 runtime with Arrow 19,
-treated a translated container as native Linux, and assumed DuckDB `UPDATE` was
-the only column-evolution path. See the provisional
-[`ADR 0045`](docs/adr/0045-dataset-artifact-spike.md).
+The measured #45 decision provisionally recommends **Parquet plus DuckDB** for
+durable artifacts, pending review of
+[`ADR 0045`](docs/adr/0045-dataset-artifact-spike.md). Native Ubuntu Gate 1
+proved that aligned Lance works under JDK 25, including version-pinned reopen,
+pre-commit recovery, LocalStack, and offline deployment. In the one-GiB Gate 2
+run, Lance met all five latency thresholds but used 2.07x Parquet's
+process-cold peak RSS and changed about 2.13 GB for both add and replace versus
+18.4/18.8 MB Parquet replacements. Those results fail the approved 1.25x RSS
+and 0.75x amplification rules.
 
-- **Lance** passes the corrected macOS compatibility, version-reopen,
-  pre-commit recovery, and derived-column smoke. Native Ubuntu remains pending.
-- **Parquet plus DuckDB** remains the conservative baseline and survives the
-  corrected macOS gate through an explicit-schema read adapter; its physical
-  schema loses the fixed width of `FLOAT[n]` embeddings.
+- **Parquet plus DuckDB** is the measured recommendation. Reads use the artifact
+  schema to restore `FLOAT[n]`, because the physical Parquet scan exposes
+  `FLOAT[]`; benchmark writes use bounded 4,096-row groups.
+- **Lance** is technically viable on the required native platforms, but its
+  helper/native operational surface is not justified by this workload's RSS
+  and column-evolution evidence.
 - **Arrow IPC** remains the default core streaming/interchange path; temporary
   IPC files are not a complete artifact system.
 - **DuckTape** may be an optional tech.ml.dataset view, but never the artifact
@@ -385,7 +389,7 @@ deployment. Dependency order matters more than issue number:
 
 - [#43](https://github.com/velio-io/collet/issues/43) modernizes the build and separates optional action dependencies.
 - [#44](https://github.com/velio-io/collet/issues/44) separates immutable definitions from durable runs, introduces embedded Datalevin 1.x on the existing Java 25 baseline, and establishes versioned semantic task/action fingerprints with a conservative non-reusable fallback.
-- [#45](https://github.com/velio-io/collet/issues/45) is rerunning the durable-format decision with aligned Lance/Arrow runtimes and native Linux evidence; no durable format is selected yet.
+- [#45](https://github.com/velio-io/collet/issues/45) provisionally recommends Parquet plus DuckDB from aligned native Linux evidence; ADR 0045 remains pending review before the format is accepted.
 - [#46](https://github.com/velio-io/collet/issues/46) implements the selected nested and extended Arrow type boundary.
 - [#48](https://github.com/velio-io/collet/issues/48) establishes artifact, one-entry dataset snapshot, materialization, publication, and lineage identities for exact whole-task reuse.
 - [#47](https://github.com/velio-io/collet/issues/47) consumes #48 to add task-local DuckDB SQL; it is not a prerequisite for the artifact store.

--- a/dev/spikes/issue-45/README.md
+++ b/dev/spikes/issue-45/README.md
@@ -19,6 +19,12 @@ bb spike:45 benchmark [--rows N] [--embedding-width N] [--memory-limit 256MiB] [
 Every public command writes machine-readable EDN and exits nonzero when a hard
 check fails. Benchmark defaults are one warm-up and three measured runs over
 1,048,576 rows x 256 `FLOAT` values: one GiB of logical embedding input.
+Every candidate uses one DuckDB worker and JDBC streaming results so the fixed
+256 MiB limit is available to the workload rather than parallel result buffers;
+both settings are recorded in the evidence. The memory-pressure workload joins
+each artifact row to 32 dimension rows and sorts the resulting 33,554,432
+default rows by a deterministic numeric hash. This exceeds 256 MiB without
+relying on DuckDB 1.5.5's non-spillable wide array or string sort records.
 After each benchmark format, the spike records inventories and hashes, closes
 the DuckDB connection, and deletes generated Lance, Parquet, Arrow, evolution,
 and spill data outside the timed operation. It repeats cleanup at the sample

--- a/dev/spikes/issue-45/README.md
+++ b/dev/spikes/issue-45/README.md
@@ -84,7 +84,7 @@ while the runtime check uses `--network none`. It records whether execution was
 native Linux or a translated container; translated Apple-Silicon results are
 never presented as native-Linux evidence.
 
-## Current provisional result
+## Final result
 
 Native Ubuntu AMD64 and macOS ARM64 pass aligned Lance latest/pinned reopen,
 DuckDB/Lance coexistence, orphan-fragment recovery, nested fidelity, JDBC
@@ -95,12 +95,18 @@ The same schema check makes Parquet's physical limitation explicit: DuckDB
 reopens its embedding as `FLOAT[]`; the Parquet adapter restores `FLOAT[n]`
 from the artifact schema and records the raw width loss as unsupported.
 
-The one-GiB native benchmark provisionally recommends Parquet. Lance passed all
-five latency limits but failed the process-cold RSS limit at 2.07x Parquet and
-both amplification limits: its add and replace each changed about 2.13 GB,
-versus 18.4 MB and 18.8 MB Parquet replacements. JDBC Arrow remains the core
-interchange, and DuckTape remains an optional TMD view only. The ADR is still
-pending review; no production format has been accepted or implemented.
+The accepted decision selects Parquet plus DuckDB for Collet-owned durable
+artifacts. Lance passed all five latency limits but failed the process-cold RSS
+limit at 2.07x Parquet and both amplification limits: its add and replace each
+changed about 2.13 GB, versus 18.4 MB and 18.8 MB Parquet replacements. JDBC
+Arrow remains the core interchange, and DuckTape remains an optional TMD view
+only. This spike does not implement the production artifact API.
+
+Lance remains viable as a user-selected destination when its long-lived,
+versioned, incremental dataset semantics are explicitly wanted. That optional
+integration is tracked in
+[#62](https://github.com/velio-io/collet/issues/62); it does not reopen the
+internal artifact decision.
 
 The translated Apple-Silicon-hosted Linux image's `liblance_jni` crash remains
 retained portability diagnostics. The passing native Ubuntu run proves that it

--- a/dev/spikes/issue-45/README.md
+++ b/dev/spikes/issue-45/README.md
@@ -86,22 +86,25 @@ never presented as native-Linux evidence.
 
 ## Current provisional result
 
-The corrected macOS ARM64 gate passes aligned Lance latest/pinned reopen,
+Native Ubuntu AMD64 and macOS ARM64 pass aligned Lance latest/pinned reopen,
 DuckDB/Lance coexistence, orphan-fragment recovery, nested fidelity, JDBC
-Arrow, DuckTape nested object values, and LocalStack reopen. A bounded smoke
-also passes Lance add/replace of a derived fixed-size embedding by using Lance
-Java's computed-column API followed by the DuckDB extension's fixed-array cast.
+Arrow, DuckTape nested object values, LocalStack reopen, and the offline image
+check. Lance add/replace of a derived fixed-size embedding passes by combining
+Lance Java's computed-column API with the DuckDB extension's fixed-array cast.
 The same schema check makes Parquet's physical limitation explicit: DuckDB
 reopens its embedding as `FLOAT[]`; the Parquet adapter restores `FLOAT[n]`
 from the artifact schema and records the raw width loss as unsupported.
 
-The translated Linux AMD64 container still crashes inside `liblance_jni` while
-opening the dataset. Its checkpoint and complete HotSpot report are retained,
-but the host is `VirtualApple`; this is portability diagnostics, not evidence
-of a native Linux failure. The manual Ubuntu workflow must decide the native
-gate before the format decision is updated. Its first run leaves
-`run_benchmark` false and stops after uploading Gate 1 evidence; after review,
-rerun it with `run_benchmark` true to authorize the full Gate 2 measurement.
+The one-GiB native benchmark provisionally recommends Parquet. Lance passed all
+five latency limits but failed the process-cold RSS limit at 2.07x Parquet and
+both amplification limits: its add and replace each changed about 2.13 GB,
+versus 18.4 MB and 18.8 MB Parquet replacements. JDBC Arrow remains the core
+interchange, and DuckTape remains an optional TMD view only. The ADR is still
+pending review; no production format has been accepted or implemented.
+
+The translated Apple-Silicon-hosted Linux image's `liblance_jni` crash remains
+retained portability diagnostics. The passing native Ubuntu run proves that it
+is not a current Lance hard blocker.
 
 See [`evidence/`](evidence/) and
 [`docs/adr/0045-dataset-artifact-spike.md`](../../../docs/adr/0045-dataset-artifact-spike.md).

--- a/dev/spikes/issue-45/README.md
+++ b/dev/spikes/issue-45/README.md
@@ -25,6 +25,10 @@ both settings are recorded in the evidence. The memory-pressure workload joins
 each artifact row to 32 dimension rows and sorts the resulting 33,554,432
 default rows by a deterministic numeric hash. This exceeds 256 MiB without
 relying on DuckDB 1.5.5's non-spillable wide array or string sort records.
+Parquet writes use the configured 4,096-row batch size as an explicit row-group
+size so adding the second fixed-width embedding does not make the writer buffer
+a default row group larger than the DuckDB limit; the setting is recorded in
+the benchmark EDN.
 After each benchmark format, the spike records inventories and hashes, closes
 the DuckDB connection, and deletes generated Lance, Parquet, Arrow, evolution,
 and spill data outside the timed operation. It repeats cleanup at the sample

--- a/dev/spikes/issue-45/evidence/gate-1-linux-amd64.edn
+++ b/dev/spikes/issue-45/evidence/gate-1-linux-amd64.edn
@@ -1,0 +1,146 @@
+{:evidence-version 1
+ :issue            45
+ :gate             :compatibility-and-recovery
+ :status           :pass
+ :source           {:workflow-run-id  31255915266
+                    :workflow-run-url "https://github.com/velio-io/collet/actions/runs/31255915266"
+                    :git-commit       "f5ebac05c619637d5e7a69903fdad799b07e366e"
+                    :artifact-name    "spike-45-linux-amd64"}
+ :timestamp        "2026-08-08T11:52:24.944386521Z"
+ :configuration    {:rows                512
+                    :embedding-width     16
+                    :batch-rows          64
+                    :duckdb-memory-limit "256MiB"}
+ :environment      {:java                {:version "25.0.3"
+                                          :vm      "OpenJDK 64-Bit Server VM"}
+                    :os                  {:name "Linux" :arch "amd64"}
+                    :dependencies        {:clojure            "1.12.5"
+                                          :duckdb-jdbc        "1.5.5.1"
+                                          :duckdb             "v1.5.5"
+                                          :main-arrow         "19.0.0"
+                                          :lance-java         "9.0.1"
+                                          :lance-helper-arrow "18.3.0"
+                                          :ducktape-git-sha   "f0fc5f38f272560821e1f9c8e7fe1634761c0580"}
+                    :native              {:lance-extension  {:version "2f167ea"
+                                                             :sha256  "a8b1463e8541a960859b05c39096a60a3c777d12fd63d9867ce62bb251ab2a1a"}
+                                          :httpfs-extension {:version "827222f"
+                                                             :sha256  "887c392b1e49128d11667c81e3698d8b00dfdeb456771acf66d05a0f74f7b7d8"}
+                                          :ducktape-duckdb  {:version "1.5.5"
+                                                             :sha256  "fc23f12e376c47be520f75221288281906e7942e8fd6f6ce4849198ba60d0405"}}
+                    :dependency-aligned? true}
+ :cases            [{:name :main-runtime-dependency-isolation :hard? true :status :pass}
+                    {:name :duckdb-jdbc-parquet
+                     :hard? true
+                     :status :pass
+                     :rows 512
+                     :value-fidelity :pass
+                     :integrated-schema-fidelity :pass
+                     :physical-schema-fidelity :fail
+                     :unsupported-physical-cells [:embedding/fixed-size-width]
+                     :physical-embedding-type "FLOAT[]"
+                     :integrated-embedding-type "FLOAT[16]"}
+                    {:name            :duckdb-jdbc-lance
+                     :hard?           true
+                     :status          :pass
+                     :rows            512
+                     :value-fidelity  :pass
+                     :schema-fidelity :pass
+                     :embedding-type  "FLOAT[16]"}
+                    {:name              :lance-second-version
+                     :hard?             true
+                     :status            :pass
+                     :rows-after-append 513}
+                    {:name                   :lance-java-reopen-latest
+                     :hard?                  true
+                     :status                 :pass
+                     :requested-version      :latest
+                     :version                2
+                     :latest-version         2
+                     :rows                   513
+                     :dependency-aligned?    true
+                     :allocator-peak-bytes   128
+                     :process-peak-rss-bytes 199155712}
+                    {:name                   :lance-java-reopen-pinned
+                     :hard?                  true
+                     :status                 :pass
+                     :requested-version      1
+                     :version                1
+                     :latest-version         2
+                     :rows                   512
+                     :dependency-aligned?    true
+                     :allocator-peak-bytes   128
+                     :process-peak-rss-bytes 199110656}
+                    {:name                   :lance-java-duckdb-coexistence
+                     :hard?                  true
+                     :status                 :pass
+                     :version                2
+                     :rows                   513
+                     :dependency-aligned?    true
+                     :same-jvm?              true
+                     :process-peak-rss-bytes 255950848}
+                    {:name                       :lance-precommit-recovery
+                     :hard?                      true
+                     :status                     :pass
+                     :child-expected-exit        86
+                     :child-actual-exit          86
+                     :committed-version-after-reopen 2
+                     :rows-after-reopen          513
+                     :orphan-fragments-excluded? true
+                     :orphan-fragment            {:bytes  212
+                                                  :sha256 "c42647eafd4fa75f4e5c038865df03d08f8be4d4e06fad0bf5629cb65f1e8ae4"}}
+                    {:name                 :jdbc-arrow-ipc
+                     :hard?                true
+                     :status               :pass
+                     :rows                 512
+                     :value-fidelity       :pass
+                     :schema-fidelity      :pass
+                     :allocator-peak-bytes 29849}
+                    {:name              :collet-arrow-common-subset
+                     :hard?             true
+                     :status            :pass
+                     :rows              512
+                     :unsupported-cells [:address :attributes :tags/null-element :events :embedding]}
+                    {:name                   :ducktape-nested-tmd-view
+                     :hard?                  false
+                     :status                 :pass
+                     :rows                   512
+                     :nested-clojure-values? true
+                     :object-columns         {:address true :attributes true :tags true :events true}
+                     :unsupported-cells      [:embedding]
+                     :omitted-null-columns   [:name :address :attributes :tags :events]}
+                    {:name   :localstack-s3-recovery
+                     :hard?  true
+                     :status :pass
+                     :rows   128
+                     :lance-projected-filtered-reopen? true
+                     :parquet-projected-filtered-reopen? true}
+                    {:name     :linux-amd64-image-no-network
+                     :hard?    true
+                     :status   :pass
+                     :platform "linux/amd64"
+                     :network  "none"}]
+ :diagnostics      [{:name        :lance-java-forced-arrow19
+                     :hard?       false
+                     :status      :observed
+                     :purpose     :reproduce-invalid-mixed-classpath
+                     :exit        1
+                     :exact-error "Execution error (UnsupportedOperationException) at io.netty.buffer.EmptyByteBuf/memoryAddress (EmptyByteBuf.java:961).\nnull"
+                     :log         {:bytes  7301
+                                   :sha256 "977cb7d4f11a5ae65593694605e240af0a995c2806989420beb4731bf6d4ac05"}}]
+ :type-matrix      [{:column :id :duckdb "BIGINT" :arrow "Int64" :collet-arrow :supported}
+                    {:column :name :duckdb "VARCHAR" :arrow "Utf8" :collet-arrow :supported}
+                    {:column :active :duckdb "BOOLEAN" :arrow "Bool" :collet-arrow :supported}
+                    {:column :score :duckdb "DOUBLE" :arrow "Float64" :collet-arrow :supported}
+                    {:column :created-at :duckdb "TIMESTAMP" :arrow "Timestamp(us)" :collet-arrow :supported}
+                    {:column :address :duckdb "STRUCT" :arrow "Struct" :collet-arrow :unsupported}
+                    {:column :attributes :duckdb "MAP(VARCHAR,VARCHAR)" :arrow "Map" :collet-arrow :unsupported}
+                    {:column :tags :duckdb "VARCHAR[]" :arrow "List<Utf8>" :collet-arrow :unsupported}
+                    {:column :events :duckdb "STRUCT[]" :arrow "List<Struct>" :collet-arrow :unsupported}
+                    {:column :embedding :duckdb "FLOAT[n]" :arrow "FixedSizeList<Float32>[n]" :collet-arrow :unsupported}]
+ :source-artifacts {:direct-edn         {:sha256 "9b04020d18ded4e9747cb21814622d3663e998be65c66117a99ad6116889dda5"}
+                    :s3-edn             {:sha256 "01c2cad00ea6f2177c2180e0568d8072ecc6d7dc1eacb632c66f50f66fc21f53"}
+                    :docker-edn         {:sha256 "8af32dd004650c734255a68c19bab3c62bed21f35e9f349f5ef490d3c3ddd74a"}
+                    :docker-build-log   {:sha256 "d791a4efe7c4f61f3ad071cff301fb8a03d346fcd247324371c2153613804773"}
+                    :docker-runtime-log {:sha256 "1a47836877344e446b27a08aa5e397df01a7224c6de496c5a90b2a7fd1ce3c2c"}}
+ :sanitization     {:removed [:absolute-workspace-paths :dependency-cache-paths :localstack-credentials]
+                    :raw-workflow-artifact-committed? false}}

--- a/dev/spikes/issue-45/evidence/gate-2-linux-amd64.edn
+++ b/dev/spikes/issue-45/evidence/gate-2-linux-amd64.edn
@@ -1,0 +1,679 @@
+{:evidence-version 1
+ :issue 45
+ :gate :measurement-and-decision
+ :status :pass
+ :source {:workflow-run-id      31258409578
+          :workflow-run-url     "https://github.com/velio-io/collet/actions/runs/31258409578"
+          :git-commit           "7693ef56982f1304cbdb9ca56387541ed122f0ff"
+          :artifact-name        "spike-45-linux-amd64"
+          :benchmark-edn-sha256 "aa4163885908eaae615745539c31c7b6f12d52123465c2326423f0b1fd836073"
+          :direct-edn-sha256    "932095e929450f39283df64dc57151cacdbc898e2bc3a8b64fef932a73f1e69e"
+          :s3-edn-sha256        "b656b5f5a181eba5b9244c6c070cbd5a4c41418193bd0c407731161f8e04473d"
+          :docker-edn-sha256    "238543eb57caee4d94678b822e8df8a1c96b544ad13a57a5292e286500f911ce"}
+ :timestamp "2026-08-08T13:14:51.144762360Z"
+ :environment {:java               {:version "25.0.3"
+                                    :vm      "OpenJDK 64-Bit Server VM"}
+               :os                 {:name "Linux" :arch "amd64"}
+               :duckdb             "v1.5.5"
+               :duckdb-jdbc        "1.5.5.1"
+               :arrow              "19.0.0"
+               :lance-extension    "2f167ea"
+               :lance-java         "9.0.1"
+               :lance-helper-arrow "18.3.0"}
+ :configuration {:rows                   1048576
+                 :embedding-width        256
+                 :logical-input-bytes    1073741824
+                 :batch-rows             4096
+                 :parquet-row-group-rows 4096
+                 :duckdb-memory-limit    "256MiB"
+                 :duckdb-threads         1
+                 :jdbc-stream-results    true
+                 :warmups                1
+                 :measured-executions    3
+                 :cold-definition        "fresh JVM and DuckDB connection; OS page cache is not flushed"}
+ :hard-gates {:direct                    :pass
+              :localstack-s3             :pass
+              :offline-linux-amd64-image :pass
+              :schema-and-evolution      :pass
+              :cleanup                   :pass}
+ :workloads {:write "write the complete generated profile table"
+             :full-sequential "consume every row through JDBC Arrow"
+             :projected-filtered "SELECT id, name WHERE id % 17 = 0"
+             :sort-join "cross join each id with range(32), sort 33,554,432 numeric rows by hash(id,bucket)"
+             :derived-embedding "add at 0.5 multiplier, then replace at 0.75 multiplier"
+             :plan {:requested            :analyze-verbose
+                    :exact-fallback-error "Not implemented Error: Unimplemented explain type: verbose"
+                    :recorded             :all
+                    :recorded-sections    [:logical-plan :optimized-logical-plan :physical-plan]}
+             :scanned-byte-note
+             "DuckDB profiling reports backend-visible bytes. Parquet reports bytes on full and sort reads; the Lance extension reports zero, so these counters are evidence but not a cross-format physical-byte claim."}
+ :warmup {:status  :pass
+          :formats {:parquet   {:status           :pass
+                                :artifact-bytes   15295724
+                                :sort-spill-bytes 660111360
+                                :schema           :pass
+                                :evolution        :pass}
+                    :lance     {:status           :pass
+                                :artifact-bytes   1169073942
+                                :sort-spill-bytes 739409920
+                                :schema           :pass
+                                :evolution        :pass}
+                    :arrow-ipc {:status         :pass
+                                :artifact-bytes 1282662386}}
+          :cleanup :pass}
+ :samples
+ [{:iteration 1
+   :status :pass
+   :parquet
+   {:artifact {:bytes 15295724
+               :files {"profiles.parquet"
+                       {:bytes  15295724
+                        :sha256 "55550f115e562e6a008ee826f44217bed8131e4efb73cee59bf9d58d2f07b750"}}}
+    :write {:elapsed-ms                12745.090619
+            :throughput-mib-per-s      80.3446621614013
+            :jvm-heap-after-used-bytes 98796688
+            :process-rss-after-bytes   1775448064
+            :duckdb-peak-buffer-bytes  11735040}
+    :full-sequential {:elapsed-ms                 3831.714042
+                      :throughput-mib-per-s       267.24332473033746
+                      :jvm-heap-after-used-bytes  117671056
+                      :process-rss-after-bytes    1807912960
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   48357080
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    1053464
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 95.514891
+                         :throughput-mib-per-s       10720.841423563996
+                         :jvm-heap-after-used-bytes  132351120
+                         :process-rss-after-bytes    1805901824
+                         :duckdb-peak-buffer-bytes   48357080
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 5856.630627
+                :throughput-mib-per-s       174.8445591359641
+                :jvm-heap-after-used-bytes  170099856
+                :process-rss-after-bytes    2035150848
+                :duckdb-peak-buffer-bytes   517095788
+                :peak-spill-directory-bytes 657784832
+                :scanned-byte-evidence      {:total-bytes-read    47616
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     4021.629312
+                   :peak-rss-bytes 707354624}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms        42174.489267
+               :replacement-bytes 18445106
+               :files             {"profiles-with-derived.parquet"
+                                   {:bytes  18445106
+                                    :sha256 "ea117bfe1151428636ef29852c6ab546fa96cf8554dd6e8523d6514736e53db8"}}}
+     :replace {:elapsed-ms        42076.840715
+               :replacement-bytes 18787184
+               :files             {"profiles-with-derived-replaced.parquet"
+                                   {:bytes  18787184
+                                    :sha256 "91aceccbfdc54954f23378d199b2c0f5ef0c37dd5132d3a52151bd631e4cccf0"}}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :lance
+   {:artifact
+    {:bytes 1169049750
+     :files
+     {"_transactions/0-022ce657-4fa8-4fa3-a7e8-62f97beb44f6.txn"
+      {:bytes  867
+       :sha256 "aaf52e7e66ab83536b32a01041cf753a04ae46692a8c96b7e18dd6cf2e254a87"}
+      "_versions/18446744073709551614.manifest"
+      {:bytes  1815
+       :sha256 "27c927a1e68352cf554dc5aea3c4fbcf5cf76919506bafb959491a2f6dc42ebe"}
+      "data/1000011110111100010100108d4c6542228453f4a16065e9ca.lance"
+      {:bytes  1169047068
+       :sha256 "e68af3e1dfcffef991d2d52cc2657d1718ef0f5e546b2dae5cc2ff50ac624bc1"}}}
+    :write {:elapsed-ms                6658.644974
+            :throughput-mib-per-s      153.78504245209214
+            :jvm-heap-after-used-bytes 186877072
+            :process-rss-after-bytes   1937977344
+            :duckdb-peak-buffer-bytes  5963776}
+    :full-sequential {:elapsed-ms                 2640.352589
+                      :throughput-mib-per-s       387.82699108675746
+                      :jvm-heap-after-used-bytes  205751440
+                      :process-rss-after-bytes    2013302784
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   5963776
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    0
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 94.712628
+                         :throughput-mib-per-s       10811.652275132732
+                         :jvm-heap-after-used-bytes  218334352
+                         :process-rss-after-bytes    2025578496
+                         :duckdb-peak-buffer-bytes   5963776
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 6366.75739
+                :throughput-mib-per-s       160.8354044726683
+                :jvm-heap-after-used-bytes  58746976
+                :process-rss-after-bytes    2277363712
+                :duckdb-peak-buffer-bytes   491884544
+                :peak-spill-directory-bytes 740130816
+                :scanned-byte-evidence      {:total-bytes-read    0
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     2834.962697
+                   :peak-rss-bytes 1452331008}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms    14975.618733
+               :amplification {:unchanged-bytes 1169049750
+                               :added-bytes     2131793911
+                               :rewritten-bytes 0
+                               :unchanged-files 3
+                               :added-files     7
+                               :rewritten-files 0}}
+     :replace {:elapsed-ms    16522.939223
+               :amplification {:unchanged-bytes 3300843648
+                               :added-bytes     2131796212
+                               :rewritten-bytes 13
+                               :unchanged-files 9
+                               :added-files     8
+                               :rewritten-files 1}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :arrow-ipc
+   {:artifact         {:bytes 1282662386
+                       :files {"profiles.arrow"
+                               {:bytes  1282662386
+                                :sha256 "7dec4d807a02bb70c461b13f7e3874c62bc84306ecdaf8e1ac28f70294be3e93"}}}
+    :write            {:elapsed-ms                 7310.189022
+                       :throughput-mib-per-s       140.07845719423588
+                       :jvm-heap-after-used-bytes  119564384
+                       :process-rss-after-bytes    1706889216
+                       :arrow-allocator-peak-bytes 10032056}
+    :full-sequential  {:elapsed-ms                 87.690276
+                       :throughput-mib-per-s       11677.46353084805
+                       :jvm-heap-after-used-bytes  123758688
+                       :process-rss-after-bytes    1710014464
+                       :arrow-allocator-peak-bytes 16777216}
+    :process-cold     {:elapsed-ms     217.544187
+                       :peak-rss-bytes 659980288}
+    :table-operations :unsupported
+    :cleanup          :pass}
+   :cleanup :pass}
+  {:iteration 2
+   :status :pass
+   :parquet
+   {:artifact {:bytes 15295724
+               :files {"profiles.parquet"
+                       {:bytes  15295724
+                        :sha256 "55550f115e562e6a008ee826f44217bed8131e4efb73cee59bf9d58d2f07b750"}}}
+    :write {:elapsed-ms                12523.107749
+            :throughput-mib-per-s      81.76884049263002
+            :jvm-heap-after-used-bytes 136341600
+            :process-rss-after-bytes   1722052608
+            :duckdb-peak-buffer-bytes  11735040}
+    :full-sequential {:elapsed-ms                 3742.74435
+                      :throughput-mib-per-s       273.5960312116963
+                      :jvm-heap-after-used-bytes  157313120
+                      :process-rss-after-bytes    1744424960
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   48283352
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    1053464
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 95.423619
+                         :throughput-mib-per-s       10731.095830687369
+                         :jvm-heap-after-used-bytes  169896032
+                         :process-rss-after-bytes    1741225984
+                         :duckdb-peak-buffer-bytes   48283352
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 5862.210364
+                :throughput-mib-per-s       174.67813954415777
+                :jvm-heap-after-used-bytes  207644768
+                :process-rss-after-bytes    1971793920
+                :duckdb-peak-buffer-bytes   517079404
+                :peak-spill-directory-bytes 660504576
+                :scanned-byte-evidence      {:total-bytes-read    47616
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     3934.610992
+                   :peak-rss-bytes 701517824}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms        42093.319079
+               :replacement-bytes 18445106
+               :files             {"profiles-with-derived.parquet"
+                                   {:bytes  18445106
+                                    :sha256 "ea117bfe1151428636ef29852c6ab546fa96cf8554dd6e8523d6514736e53db8"}}}
+     :replace {:elapsed-ms        42007.89451
+               :replacement-bytes 18787184
+               :files             {"profiles-with-derived-replaced.parquet"
+                                   {:bytes  18787184
+                                    :sha256 "91aceccbfdc54954f23378d199b2c0f5ef0c37dd5132d3a52151bd631e4cccf0"}}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :lance
+   {:artifact
+    {:bytes 1169071317
+     :files
+     {"_transactions/0-f72c977a-c31b-40de-976d-14f6e963c195.txn"
+      {:bytes  867
+       :sha256 "f4da984850c9765ad29e49f6d94245238e0fc70d1b06bec57b14bfbdc355db9c"}
+      "_versions/18446744073709551614.manifest"
+      {:bytes  1814
+       :sha256 "4479458a816ef8b57ec74daad6f30eeac888aaf07fdb731b4f821453447f27ae"}
+      "data/1010101000001000000100108de26847cf86d53c3f760409b0.lance"
+      {:bytes  1169068636
+       :sha256 "50db2c052bdbc473b8086cf2ec21bc7490fc06029f04496fe95564425cf0ee71"}}}
+    :write {:elapsed-ms                6586.407519
+            :throughput-mib-per-s      155.4717039670014
+            :jvm-heap-after-used-bytes 224421984
+            :process-rss-after-bytes   1812250624
+            :duckdb-peak-buffer-bytes  5963776}
+    :full-sequential {:elapsed-ms                 2636.813229
+                      :throughput-mib-per-s       388.3475661976816
+                      :jvm-heap-after-used-bytes  243296352
+                      :process-rss-after-bytes    1991974912
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   5963776
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    0
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 102.819042
+                         :throughput-mib-per-s       9959.244708776805
+                         :jvm-heap-after-used-bytes  59852512
+                         :process-rss-after-bytes    2005061632
+                         :duckdb-peak-buffer-bytes   5963776
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 6264.306637
+                :throughput-mib-per-s       163.46581662394442
+                :jvm-heap-after-used-bytes  95504096
+                :process-rss-after-bytes    2255032320
+                :duckdb-peak-buffer-bytes   491978752
+                :peak-spill-directory-bytes 746651648
+                :scanned-byte-evidence      {:total-bytes-read    0
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     2846.018644
+                   :peak-rss-bytes 1514962944}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms    14988.029823
+               :amplification {:unchanged-bytes 1169071317
+                               :added-bytes     2131793911
+                               :rewritten-bytes 0
+                               :unchanged-files 3
+                               :added-files     7
+                               :rewritten-files 0}}
+     :replace {:elapsed-ms    16646.369922
+               :amplification {:unchanged-bytes 3300865215
+                               :added-bytes     2131796212
+                               :rewritten-bytes 13
+                               :unchanged-files 9
+                               :added-files     8
+                               :rewritten-files 1}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :arrow-ipc
+   {:artifact         {:bytes 1282662386
+                       :files {"profiles.arrow"
+                               {:bytes  1282662386
+                                :sha256 "a4d3deb9852c159cd6c7e09b95270d5223bb6bf72cf9e7aec2d3b33c731db179"}}}
+    :write            {:elapsed-ms                 7325.645523
+                       :throughput-mib-per-s       139.78290333391004
+                       :jvm-heap-after-used-bytes  156321504
+                       :process-rss-after-bytes    1783648256
+                       :arrow-allocator-peak-bytes 10032056}
+    :full-sequential  {:elapsed-ms                 85.904151
+                       :throughput-mib-per-s       11920.2621535716
+                       :jvm-heap-after-used-bytes  160515808
+                       :process-rss-after-bytes    1790300160
+                       :arrow-allocator-peak-bytes 16777216}
+    :process-cold     {:elapsed-ms     174.434215
+                       :peak-rss-bytes 658673664}
+    :table-operations :unsupported
+    :cleanup          :pass}
+   :cleanup :pass}
+  {:iteration 3
+   :status :pass
+   :parquet
+   {:artifact {:bytes 15295724
+               :files {"profiles.parquet"
+                       {:bytes  15295724
+                        :sha256 "55550f115e562e6a008ee826f44217bed8131e4efb73cee59bf9d58d2f07b750"}}}
+    :write {:elapsed-ms                12558.658438
+            :throughput-mib-per-s      81.53737161141193
+            :jvm-heap-after-used-bytes 173098720
+            :process-rss-after-bytes   1805148160
+            :duckdb-peak-buffer-bytes  11735040}
+    :full-sequential {:elapsed-ms                 3761.1425
+                      :throughput-mib-per-s       272.2576982924736
+                      :jvm-heap-after-used-bytes  191973088
+                      :process-rss-after-bytes    1822941184
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   48283352
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    1053464
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 96.001287
+                         :throughput-mib-per-s       10666.523668583734
+                         :jvm-heap-after-used-bytes  206653152
+                         :process-rss-after-bytes    1821347840
+                         :duckdb-peak-buffer-bytes   48283352
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 5806.420005
+                :throughput-mib-per-s       176.35651556694444
+                :jvm-heap-after-used-bytes  244401888
+                :process-rss-after-bytes    2053341184
+                :duckdb-peak-buffer-bytes   517079404
+                :peak-spill-directory-bytes 664436736
+                :scanned-byte-evidence      {:total-bytes-read    47616
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     3993.126256
+                   :peak-rss-bytes 661913600}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms        42121.367196
+               :replacement-bytes 18445106
+               :files             {"profiles-with-derived.parquet"
+                                   {:bytes  18445106
+                                    :sha256 "ea117bfe1151428636ef29852c6ab546fa96cf8554dd6e8523d6514736e53db8"}}}
+     :replace {:elapsed-ms        42028.043447
+               :replacement-bytes 18787184
+               :files             {"profiles-with-derived-replaced.parquet"
+                                   {:bytes  18787184
+                                    :sha256 "91aceccbfdc54954f23378d199b2c0f5ef0c37dd5132d3a52151bd631e4cccf0"}}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :lance
+   {:artifact
+    {:bytes 1169041558
+     :files
+     {"_transactions/0-757928b0-3f1b-4782-8f58-fe6781299861.txn"
+      {:bytes  867
+       :sha256 "9eb16564ef42049f4691fa39b0567f4fbc7a9e8d1a3152e4e4090693020c9553"}
+      "_versions/18446744073709551614.manifest"
+      {:bytes  1815
+       :sha256 "8c5babd7a6e7be890a8311d599a7ab81182339161bea37ea1ea6be3d26f7116d"}
+      "data/10111111110110110001001126aaed4821b6cb081e14bd6cec.lance"
+      {:bytes  1169038876
+       :sha256 "03cfa6f22a4f8c013cdb88357642b194e31f1b670867d3996db734ec2ae6d6ff"}}}
+    :write {:elapsed-ms                6548.291139
+            :throughput-mib-per-s      156.37667572556597
+            :jvm-heap-after-used-bytes 64161864
+            :process-rss-after-bytes   1878028288
+            :duckdb-peak-buffer-bytes  5963776}
+    :full-sequential {:elapsed-ms                 2625.69327
+                      :throughput-mib-per-s       389.9922400303825
+                      :jvm-heap-after-used-bytes  83036232
+                      :process-rss-after-bytes    1982148608
+                      :arrow-allocator-peak-bytes 10032056
+                      :duckdb-peak-buffer-bytes   5963776
+                      :peak-spill-directory-bytes 0
+                      :scanned-byte-evidence      {:total-bytes-read    0
+                                                   :total-bytes-written 0}
+                      :plan-mode                  :all}
+    :projected-filtered {:elapsed-ms                 91.40294
+                         :throughput-mib-per-s       11203.140730484161
+                         :jvm-heap-after-used-bytes  95619144
+                         :process-rss-after-bytes    1987469312
+                         :duckdb-peak-buffer-bytes   5963776
+                         :peak-spill-directory-bytes 0
+                         :scanned-byte-evidence      {:total-bytes-read    0
+                                                      :total-bytes-written 0}
+                         :plan-mode                  :all}
+    :sort-join {:elapsed-ms                 6241.43842
+                :throughput-mib-per-s       164.0647445497027
+                :jvm-heap-after-used-bytes  133367880
+                :process-rss-after-bytes    2243284992
+                :duckdb-peak-buffer-bytes   491950080
+                :peak-spill-directory-bytes 744816640
+                :scanned-byte-evidence      {:total-bytes-read    0
+                                             :total-bytes-written 0}
+                :bounded-or-spilled?        true
+                :plan-mode                  :all}
+    :process-cold {:elapsed-ms     2782.821068
+                   :peak-rss-bytes 1415458816}
+    :derived-embedding
+    {:status  :pass
+     :add     {:elapsed-ms    14743.932444
+               :amplification {:unchanged-bytes 1169041558
+                               :added-bytes     2131793911
+                               :rewritten-bytes 0
+                               :unchanged-files 3
+                               :added-files     7
+                               :rewritten-files 0}}
+     :replace {:elapsed-ms    16657.465475
+               :amplification {:unchanged-bytes 3300835456
+                               :added-bytes     2131796212
+                               :rewritten-bytes 13
+                               :unchanged-files 9
+                               :added-files     8
+                               :rewritten-files 1}}}
+    :schema :pass
+    :profiles :pass
+    :cleanup :pass}
+   :arrow-ipc
+   {:artifact         {:bytes 1282662386
+                       :files {"profiles.arrow"
+                               {:bytes  1282662386
+                                :sha256 "aea50975cac3ea777a048989aed8ccf0a28c78dbf2bc1ed800dd4628bc962756"}}}
+    :write            {:elapsed-ms                 7294.181838
+                       :throughput-mib-per-s       140.38586132653523
+                       :jvm-heap-after-used-bytes  194185288
+                       :process-rss-after-bytes    1787953152
+                       :arrow-allocator-peak-bytes 10032056}
+    :full-sequential  {:elapsed-ms                 86.172201
+                       :throughput-mib-per-s       11883.18260549014
+                       :jvm-heap-after-used-bytes  198379592
+                       :process-rss-after-bytes    1805864960
+                       :arrow-allocator-peak-bytes 16777216}
+    :process-cold     {:elapsed-ms     195.138224
+                       :peak-rss-bytes 648327168}
+    :table-operations :unsupported
+    :cleanup          :pass}
+   :cleanup :pass}]
+ :medians
+ {:parquet
+  {:artifact-bytes     15295724
+   :write              {:elapsed-ms                12558.658438
+                        :throughput-mib-per-s      81.53737161141193
+                        :jvm-heap-after-used-bytes 136341600
+                        :process-rss-after-bytes   1775448064}
+   :full-sequential    {:elapsed-ms                 3761.1425
+                        :throughput-mib-per-s       272.2576982924736
+                        :jvm-heap-after-used-bytes  157313120
+                        :process-rss-after-bytes    1807912960
+                        :arrow-allocator-peak-bytes 10032056}
+   :projected-filtered {:elapsed-ms                95.514891
+                        :throughput-mib-per-s      10720.841423563996
+                        :jvm-heap-after-used-bytes 169896032
+                        :process-rss-after-bytes   1805901824
+                        :duckdb-peak-buffer-bytes  48283352}
+   :sort-join          {:elapsed-ms                 5856.630627
+                        :throughput-mib-per-s       174.8445591359641
+                        :jvm-heap-after-used-bytes  207644768
+                        :process-rss-after-bytes    2035150848
+                        :duckdb-peak-buffer-bytes   517079404
+                        :peak-spill-directory-bytes 660504576}
+   :process-cold       {:elapsed-ms     3993.126256
+                        :peak-rss-bytes 701517824}
+   :derived-embedding  {:add-elapsed-ms            42121.367196
+                        :replace-elapsed-ms        42028.043447
+                        :add-replacement-bytes     18445106
+                        :replace-replacement-bytes 18787184}}
+  :lance
+  {:artifact-bytes     1169049750
+   :write              {:elapsed-ms                6586.407519
+                        :throughput-mib-per-s      155.4717039670014
+                        :jvm-heap-after-used-bytes 186877072
+                        :process-rss-after-bytes   1878028288}
+   :full-sequential    {:elapsed-ms                 2636.813229
+                        :throughput-mib-per-s       388.3475661976816
+                        :jvm-heap-after-used-bytes  205751440
+                        :process-rss-after-bytes    1991974912
+                        :arrow-allocator-peak-bytes 10032056}
+   :projected-filtered {:elapsed-ms                94.712628
+                        :throughput-mib-per-s      10811.652275132732
+                        :jvm-heap-after-used-bytes 95619144
+                        :process-rss-after-bytes   2005061632
+                        :duckdb-peak-buffer-bytes  5963776}
+   :sort-join          {:elapsed-ms                 6264.306637
+                        :throughput-mib-per-s       163.46581662394442
+                        :jvm-heap-after-used-bytes  95504096
+                        :process-rss-after-bytes    2255032320
+                        :duckdb-peak-buffer-bytes   491950080
+                        :peak-spill-directory-bytes 744816640}
+   :process-cold       {:elapsed-ms     2834.962697
+                        :peak-rss-bytes 1452331008}
+   :derived-embedding  {:add-elapsed-ms                 14975.618733
+                        :replace-elapsed-ms             16646.369922
+                        :add-added-plus-rewritten-bytes 2131793911
+                        :replace-added-plus-rewritten-bytes 2131796225}}
+  :arrow-ipc
+  {:artifact-bytes  1282662386
+   :write           {:elapsed-ms                 7310.189022
+                     :throughput-mib-per-s       140.07845719423588
+                     :jvm-heap-after-used-bytes  156321504
+                     :process-rss-after-bytes    1783648256
+                     :arrow-allocator-peak-bytes 10032056}
+   :full-sequential {:elapsed-ms                 86.172201
+                     :throughput-mib-per-s       11883.18260549014
+                     :jvm-heap-after-used-bytes  160515808
+                     :process-rss-after-bytes    1790300160
+                     :arrow-allocator-peak-bytes 16777216}
+   :process-cold    {:elapsed-ms     195.138224
+                     :peak-rss-bytes 658673664}}}
+ :decision
+ {:hard-gates-pass? true
+  :rules            [{:metric                 :write-latency
+                      :threshold              {:operator :<= :value 1.2}
+                      :lance-to-parquet-ratio 0.5244515209579108
+                      :pass?                  true}
+                     {:metric                 :full-sequential-latency
+                      :threshold              {:operator :<= :value 1.2}
+                      :lance-to-parquet-ratio 0.7010670903854347
+                      :pass?                  true}
+                     {:metric                 :projected-filtered-latency
+                      :threshold              {:operator :<= :value 1.2}
+                      :lance-to-parquet-ratio 0.9916006499970773
+                      :pass?                  true}
+                     {:metric                 :sort-join-latency
+                      :threshold              {:operator :<= :value 1.2}
+                      :lance-to-parquet-ratio 1.069609308826913
+                      :pass?                  true}
+                     {:metric                 :process-cold-latency
+                      :threshold              {:operator :<= :value 1.2}
+                      :lance-to-parquet-ratio 0.7099606962690538
+                      :pass?                  true}
+                     {:metric                 :process-cold-peak-rss
+                      :threshold              {:operator :<= :value 1.25}
+                      :lance-to-parquet-ratio 2.070269575930262
+                      :pass?                  false}
+                     {:metric                 :add-amplification
+                      :threshold              {:operator :<= :value 0.75}
+                      :lance-to-parquet-ratio 115.57504256142524
+                      :pass?                  false}
+                     {:metric                 :replace-amplification
+                      :threshold              {:operator :<= :value 0.75}
+                      :lance-to-parquet-ratio 113.47076948839167
+                      :pass?                  false}]
+  :recommendation   {:format           :parquet
+                     :status           :provisional-pending-review
+                     :core-interchange :jdbc-arrow
+                     :ducktape         :optional-tmd-view-only
+                     :reason           [:cold-process-rss-threshold-failed
+                                        :add-amplification-threshold-failed
+                                        :replace-amplification-threshold-failed]}}
+ :invalid-runs
+ [{:workflow-run-id 31256106128
+   :workflow-run-url "https://github.com/velio-io/collet/actions/runs/31256106128"
+   :benchmark-edn-sha256 "7e40b2de7f5f3b3f58f7e1c63a4574609db010f442258f5ea518476843e9a4a0"
+   :classification :invalid-benchmark
+   :repair :enable-jdbc-stream-results
+   :errors
+   [{:format :parquet
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to allocate data of size 16.0 KiB (255.9 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}
+    {:format :lance
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to pin block of size 256.0 KiB (256.3 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}
+    {:format :arrow-ipc
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to pin block of size 256.0 KiB (256.5 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}]}
+  {:workflow-run-id 31256647289
+   :workflow-run-url "https://github.com/velio-io/collet/actions/runs/31256647289"
+   :benchmark-edn-sha256 "07e7fca12259698bd7f907e16b46c3e0278c858ec793b6e7050febc41806c3c9"
+   :classification :invalid-benchmark
+   :repair :remove-unrequired-order-by-from-streaming-operations
+   :errors
+   [{:format :parquet
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: could not allocate block of size 256.0 KiB (256.6 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}
+    {:format :lance
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to pin block of size 256.0 KiB (256.3 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}
+    {:format :arrow-ipc
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to pin block of size 256.0 KiB (256.7 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}]}
+  {:workflow-run-id 31256997074
+   :workflow-run-url "https://github.com/velio-io/collet/actions/runs/31256997074"
+   :benchmark-edn-sha256 "8153ec9e51a27d3f35c3cee17713bc6563382df081570a798a117b071f0952bc"
+   :classification :invalid-benchmark
+   :repair :replace-nonspillable-wide-sort-with-numeric-sort-join
+   :errors
+   [{:format :parquet
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: could not allocate block of size 256.0 KiB (256.1 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}
+    {:format :lance
+     :class "java.sql.SQLException"
+     :message
+     "Out of Memory Error: failed to pin block of size 256.0 KiB (255.8 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}]}
+  {:workflow-run-id 31257800270
+   :workflow-run-url "https://github.com/velio-io/collet/actions/runs/31257800270"
+   :benchmark-edn-sha256 "db2fe05308f9b8f57797345742681ab309522b65594bf29939b05b3c308e4282"
+   :classification :invalid-benchmark
+   :repair :set-parquet-row-group-rows-to-batch-size
+   :errors
+   [{:format :parquet
+     :class "java.sql.SQLException"
+     :operation :add-derived-embedding
+     :message
+     "Out of Memory Error: failed to allocate data of size 32.0 MiB (235.0 MiB/256.0 MiB used)\n\nPossible solutions:\n* Reducing the number of threads (SET threads=X)\n* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n* Increasing the memory limit (SET memory_limit='...GB')\n\nSee also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads"}]}]
+ :sanitization {:removed [:absolute-workspace-paths :dependency-cache-paths :localstack-credentials]
+                :raw-workflow-artifact-committed? false
+                :generated-dataset-binaries-uploaded? false}}

--- a/dev/spikes/issue-45/src/collet/spike/issue_45.clj
+++ b/dev/spikes/issue-45/src/collet/spike/issue_45.clj
@@ -1131,9 +1131,11 @@
         connection     (streaming-duckdb-connection)]
     (sql! connection (str "SET memory_limit = " (sql-literal (:duckdb-memory-limit config))))
     (sql! connection (str "SET temp_directory = " (sql-literal (.toAbsolutePath temp-directory))))
+    (sql! connection "SET threads = 1")
     (sql! connection "SET preserve_insertion_order = false")
     {:connection          connection
      :spill-directory     temp-directory
+     :duckdb-threads      1
      :jdbc-stream-results true}))
 
 
@@ -1168,13 +1170,13 @@
     (case operation
       :full-sequential (str "SELECT * FROM " scan)
       :projected-filtered (str "SELECT id, name FROM " scan " WHERE id % 17 = 0")
-      ;; The sort key is the full embedding. It keeps the work substantially
-      ;; above the 256 MiB default rather than merely sorting scalar IDs.
+      ;; Expand each profile across 32 dimension rows, then sort the resulting
+      ;; 33,554,432 default rows by a numeric key. This exceeds 256 MiB while
+      ;; remaining spillable in DuckDB 1.5.5; wide array/string sort records do not.
       :sort-join (str "SELECT p.id FROM "
                       scan
-                      " p JOIN "
-                      scan
-                      " q ON p.id = q.id ORDER BY p.embedding")
+                      " p CROSS JOIN range(32) q(bucket) "
+                      "ORDER BY hash(p.id, q.bucket)")
       (throw (ex-info "Unknown benchmark operation" {:operation operation})))))
 
 
@@ -1200,6 +1202,7 @@
   (with-open [connection (streaming-duckdb-connection)]
     (sql! connection (str "SET memory_limit = " (sql-literal memory-limit)))
     (sql! connection (str "SET temp_directory = " (sql-literal temp-directory)))
+    (sql! connection "SET threads = 1")
     (let [format (keyword format)
           result (case format
                    :arrow (measure! 0 #(consume-arrow-ipc! (Paths/get path (make-array String 0))))
@@ -1224,6 +1227,7 @@
                    (throw (ex-info "Unknown cold-read format" {:format format})))]
       {:fresh-jvm               true
        :fresh-duckdb-connection true
+       :duckdb-threads          1
        :jdbc-stream-results     true
        :os-page-cache           :not-flushed
        :format                  format
@@ -2132,12 +2136,13 @@
   [config phase iteration formats]
   (let [artifact-directory (unique-artifact-directory config
                                                       (str "benchmark-" (name phase) "-" iteration))
-        {:keys [connection spill-directory jdbc-stream-results]}
+        {:keys [connection spill-directory duckdb-threads jdbc-stream-results]}
         (benchmark-connection! artifact-directory config)
         environment        (with-open [connection connection]
                              (create-benchmark-profiles! connection config)
                              (cond-> {:duckdb-version      (duckdb-version connection)
                                       :logical-input-bytes (logical-input-bytes config)
+                                      :duckdb-threads      duckdb-threads
                                       :jdbc-stream-results jdbc-stream-results
                                       :profile-schema      (query-rows connection "DESCRIBE profiles")
                                       :artifact-directory  (.toString artifact-directory)

--- a/dev/spikes/issue-45/src/collet/spike/issue_45.clj
+++ b/dev/spikes/issue-45/src/collet/spike/issue_45.clj
@@ -1167,7 +1167,7 @@
   (let [scan (format-scan-sql format path embedding-width)]
     (case operation
       :full-sequential (str "SELECT * FROM " scan)
-      :projected-filtered (str "SELECT id, name FROM " scan " WHERE id % 17 = 0 ORDER BY id")
+      :projected-filtered (str "SELECT id, name FROM " scan " WHERE id % 17 = 0")
       ;; The sort key is the full embedding. It keeps the work substantially
       ;; above the 256 MiB default rather than merely sorting scalar IDs.
       :sort-join (str "SELECT p.id FROM "
@@ -1566,9 +1566,9 @@
 
 
 (defn- jdbc-arrow->ipc!
-  [^Connection connection ^Path path batch-size]
+  [^Connection connection ^Path path batch-size sql]
   (with-open [statement  (.createStatement connection)
-              result-set ^DuckDBResultSet (.executeQuery statement "SELECT * FROM profiles ORDER BY id")
+              result-set ^DuckDBResultSet (.executeQuery statement sql)
               allocator  (RootAllocator.)
               reader     (.arrowExportStream result-set allocator (int batch-size))
               output     (FileOutputStream. (.toFile path))]
@@ -1731,7 +1731,10 @@
             (checked :jdbc-arrow-ipc
                      true
                      #(let [path     (.resolve artifacts "profiles.arrow")
-                            export   (jdbc-arrow->ipc! connection path (:batch-rows config))
+                            export   (jdbc-arrow->ipc! connection
+                                                       path
+                                                       (:batch-rows config)
+                                                       "SELECT * FROM profiles ORDER BY id")
                             readback (arrow-ipc-data path)
                             values   (fidelity baseline (:rows readback))
                             schema   {:status   (if (= (:schema export) (:schema readback)) :pass :fail)
@@ -2074,10 +2077,14 @@
   [^Connection connection config ^Path artifact-directory]
   (let [directory (ensure-directory! (.resolve artifact-directory "arrow"))
         artifact  (.resolve directory "profiles.arrow")
+        sql       "SELECT * FROM profiles"
         write     (measure! (logical-input-bytes config)
-                            #(let [export    (jdbc-arrow->ipc! connection artifact (:batch-rows config))
+                            #(let [export    (jdbc-arrow->ipc! connection
+                                                               artifact
+                                                               (:batch-rows config)
+                                                               sql)
                                    inventory (artifact-inventory artifact)]
-                               {:export export :inventory inventory}))
+                               {:sql sql :export export :inventory inventory}))
         full      (measure! (logical-input-bytes config) #(consume-arrow-ipc! artifact))
         cold      (cold-read-case config :arrow artifact (.resolve artifact-directory "duckdb-spill"))]
     {:status             (if (= :pass (:status cold)) :pass :fail)

--- a/dev/spikes/issue-45/src/collet/spike/issue_45.clj
+++ b/dev/spikes/issue-45/src/collet/spike/issue_45.clj
@@ -1147,9 +1147,13 @@
 
 
 (defn- format-write-sql
-  [format path]
+  [config format path]
   (case format
-    :parquet (str "COPY profiles TO " (sql-literal path) " (FORMAT PARQUET, COMPRESSION zstd)")
+    :parquet (str "COPY profiles TO "
+                  (sql-literal path)
+                  " (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE "
+                  (:batch-rows config)
+                  ")")
     :lance (str "COPY profiles TO "
                 (sql-literal path)
                 " (FORMAT lance, MODE 'overwrite', data_storage_version '2.2')")
@@ -1969,6 +1973,9 @@
         replace-artifact   (.resolve directory "profiles-with-derived-replaced.parquet")
         add-expression     (derived-embedding-sql (:embedding-width config) "0.5")
         replace-expression (derived-embedding-sql (:embedding-width config) "0.75")
+        copy-options       (str " (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE "
+                                (:batch-rows config)
+                                ")")
         before             (artifact-inventory artifact)
         add                (measure! (logical-input-bytes config)
                                      #(let [sql (str "COPY (SELECT *, "
@@ -1979,7 +1986,7 @@
                                                                       (:embedding-width config))
                                                      ") TO "
                                                      (sql-literal add-artifact)
-                                                     " (FORMAT PARQUET, COMPRESSION zstd)")]
+                                                     copy-options)]
                                         {:statement (profiled-statement! connection
                                                                          (benchmark-profile-path artifact-directory :parquet :add-derived)
                                                                          sql)
@@ -1994,7 +2001,7 @@
                                                                       (:embedding-width config))
                                                      ") TO "
                                                      (sql-literal replace-artifact)
-                                                     " (FORMAT PARQUET, COMPRESSION zstd)")]
+                                                     copy-options)]
                                         {:statement (profiled-statement! connection
                                                                          (benchmark-profile-path artifact-directory :parquet :replace-derived)
                                                                          sql)
@@ -2027,7 +2034,7 @@
   [^Connection connection config ^Path artifact-directory format]
   (let [directory   (ensure-directory! (.resolve artifact-directory (name format)))
         artifact    (.resolve directory (if (= format :lance) "profiles.lance" "profiles.parquet"))
-        write-sql   (format-write-sql format artifact)
+        write-sql   (format-write-sql config format artifact)
         write       (measure! (logical-input-bytes config)
                               #(let [statement (profiled-statement!
                                                 connection
@@ -2180,12 +2187,13 @@
                            (range 1 (inc (:repetitions config))))
         samples      (into [warmup] measured)]
     {:status    (if (some #(not= :pass (:status %)) samples) :fail :pass)
-     :benchmark {:warmups             1
-                 :measured-executions (:repetitions config)
-                 :cold-definition     "fresh JVM and DuckDB connection; OS page cache is not flushed"
-                 :logical-input-bytes (logical-input-bytes config)
-                 :surviving-formats   survivors
-                 :disqualified        disqualified}
+     :benchmark {:warmups                1
+                 :measured-executions    (:repetitions config)
+                 :cold-definition        "fresh JVM and DuckDB connection; OS page cache is not flushed"
+                 :logical-input-bytes    (logical-input-bytes config)
+                 :parquet-row-group-rows (:batch-rows config)
+                 :surviving-formats      survivors
+                 :disqualified           disqualified}
      :warmup    warmup
      :measured  measured}))
 

--- a/dev/spikes/issue-45/src/collet/spike/issue_45.clj
+++ b/dev/spikes/issue-45/src/collet/spike/issue_45.clj
@@ -19,7 +19,7 @@
     [java.math BigInteger]
     [java.sql Array Connection DriverManager ResultSet ResultSetMetaData SQLException Struct Timestamp]
     [java.time Instant LocalDateTime ZoneOffset]
-    [java.util Map UUID]
+    [java.util Map Properties UUID]
     [java.util.zip ZipInputStream]
     [org.apache.arrow.memory RootAllocator]
     [org.apache.arrow.vector VectorSchemaRoot]
@@ -1118,15 +1118,23 @@
     [:spill (.resolve artifact-directory "duckdb-spill")]]))
 
 
+(defn- streaming-duckdb-connection
+  []
+  (let [properties (doto (Properties.)
+                     (.setProperty "jdbc_stream_results" "true"))]
+    (DriverManager/getConnection "jdbc:duckdb:" properties)))
+
+
 (defn- benchmark-connection!
   [^Path artifact-directory config]
   (let [temp-directory (ensure-directory! (.resolve artifact-directory "duckdb-spill"))
-        connection     (DriverManager/getConnection "jdbc:duckdb:")]
+        connection     (streaming-duckdb-connection)]
     (sql! connection (str "SET memory_limit = " (sql-literal (:duckdb-memory-limit config))))
     (sql! connection (str "SET temp_directory = " (sql-literal (.toAbsolutePath temp-directory))))
     (sql! connection "SET preserve_insertion_order = false")
-    {:connection      connection
-     :spill-directory temp-directory}))
+    {:connection          connection
+     :spill-directory     temp-directory
+     :jdbc-stream-results true}))
 
 
 (defn- create-benchmark-profiles!
@@ -1189,7 +1197,7 @@
 (defn- cold-read!
   [format path embedding-width memory-limit temp-directory batch-size]
   (Class/forName "org.duckdb.DuckDBDriver")
-  (with-open [connection (DriverManager/getConnection "jdbc:duckdb:")]
+  (with-open [connection (streaming-duckdb-connection)]
     (sql! connection (str "SET memory_limit = " (sql-literal memory-limit)))
     (sql! connection (str "SET temp_directory = " (sql-literal temp-directory)))
     (let [format (keyword format)
@@ -1216,6 +1224,7 @@
                    (throw (ex-info "Unknown cold-read format" {:format format})))]
       {:fresh-jvm               true
        :fresh-duckdb-connection true
+       :jdbc-stream-results     true
        :os-page-cache           :not-flushed
        :format                  format
        :result                  result})))
@@ -2116,11 +2125,13 @@
   [config phase iteration formats]
   (let [artifact-directory (unique-artifact-directory config
                                                       (str "benchmark-" (name phase) "-" iteration))
-        {:keys [connection spill-directory]} (benchmark-connection! artifact-directory config)
+        {:keys [connection spill-directory jdbc-stream-results]}
+        (benchmark-connection! artifact-directory config)
         environment        (with-open [connection connection]
                              (create-benchmark-profiles! connection config)
                              (cond-> {:duckdb-version      (duckdb-version connection)
                                       :logical-input-bytes (logical-input-bytes config)
+                                      :jdbc-stream-results jdbc-stream-results
                                       :profile-schema      (query-rows connection "DESCRIBE profiles")
                                       :artifact-directory  (.toString artifact-directory)
                                       :spill-directory     (.toString spill-directory)}

--- a/docs/adr/0045-dataset-artifact-spike.md
+++ b/docs/adr/0045-dataset-artifact-spike.md
@@ -1,15 +1,18 @@
 # ADR 0045: Reopen the Lance decision with aligned runtimes
 
-Status: provisional. The earlier Parquet acceptance is withdrawn. No production
-artifact contract or publishable dependency is introduced by this spike.
+Status: provisional pending review. No production artifact contract or
+publishable dependency is introduced by this spike.
 
 ## Provisional decision
 
-Keep the durable artifact format unresolved until the corrected native Ubuntu
-Gate 1 and one-GiB Gate 2 run completes. Lance and Parquet are both still
-candidates. JDBC Arrow 19 remains the default core interchange regardless of
-the durable-format result. DuckTape may only be an optional tech.ml.dataset
-view and never the artifact contract.
+Recommend Parquet plus DuckDB for the durable artifact format. Lance passed
+every compatibility and recovery hard gate and met every latency threshold,
+but it failed the predetermined process-cold RSS and both rewrite-amplification
+thresholds. The recommendation remains provisional until review; this spike
+does not accept the format or start its production implementation.
+
+JDBC Arrow 19 remains the default core interchange. DuckTape may only be an
+optional tech.ml.dataset view and never the artifact contract.
 
 The earlier Lance rejection was based on three invalid inferences:
 
@@ -76,25 +79,25 @@ either an IPC hop or a new lifetime-aware C Data-to-TMD adapter; nested and
 fixed-size-list mappings remain issue #46 work. DuckTape remains the smaller
 optional TMD path.
 
-FFM is therefore a separately approval-gated fallback, not a way to reinterpret
-the translated-container crash. Finish the native Ubuntu gate first. Only an
-authoritative native failure plausibly isolated to JNI should trigger a narrow
-FFM probe limited to open, version, row count, and projected scan before any
-write or object-store surface is considered.
+FFM is therefore deferred. Native Ubuntu passed the Lance Java and DuckDB Lance
+paths, so there is no immediate justification for Collet to own a Rust C ABI.
+Revisit a narrow FFM probe only for a future failure plausibly isolated to JNI
+or a measured control-plane need that the supported bindings cannot satisfy.
 
-## Corrected Gate 1 evidence
+## Gate 1 evidence
 
-The aligned macOS ARM64 / JDK 25.0.1 functional run passes:
+Native Ubuntu AMD64 on JDK 25.0.3 passes, and the macOS ARM64 functional run
+also passes:
 
 - full nested value fidelity through DuckDB Parquet, DuckDB Lance, and JDBC
   Arrow;
-- latest Lance version 2 with 17 rows and explicitly pinned version 1 with 16
+- latest Lance version 2 with 513 rows and explicitly pinned version 1 with 512
   rows after a fresh JVM restart;
 - DuckDB JDBC, the DuckDB Lance extension, Lance Java 9.0.1, and Arrow 18.3 in
   one aligned helper JVM;
 - one uncommitted child-created fragment excluded after the child force-halts
   with exit 86 before cleanup or commit, with the prior committed version and
-  17-row count retained;
+  513-row count retained;
 - existing Collet Arrow on its supported scalar/timestamp subset;
 - DuckTape maps/vectors for nullable `STRUCT`, `MAP`, `LIST`, and `LIST<STRUCT>`
   object columns; fixed-size arrays remain explicitly unsupported there;
@@ -117,8 +120,9 @@ Execution error (UnsupportedOperationException) at io.netty.buffer.EmptyByteBuf/
 null
 ```
 
-The complete 5,818-byte Clojure report is retained in `output.log` with SHA-256
-`5a6c63503a00f6bdd4f154f55550d1ad1fd9210d071d1b7effd64151898c5feb`.
+The native run's complete 7,301-byte Clojure report is retained in `output.log`
+with SHA-256
+`977cb7d4f11a5ae65593694605e240af0a995c2806989420beb4731bf6d4ac05`.
 This diagnostic is non-qualifying because the runtime deliberately contradicts
 Lance's declared Arrow dependency.
 
@@ -137,9 +141,9 @@ The report identifies `Host: VirtualApple`, Java 25.0.3, Lance 9.0.1, and Arrow
 `4ee1e2aaa777e9e434da306e54b7da90a646755b620b139b664004384ef87ac2`.
 The full report, combined output, checkpoints, sizes, and hashes are retained
 for this exact run. The checkpoint boundary repeats across translated runs,
-while addresses, PIDs, and extracted-library names are run-specific. This is
-not evidence that native Ubuntu fails. The manual workflow is the authority
-for that hard gate.
+while addresses, PIDs, and extracted-library names are run-specific. Native
+Ubuntu subsequently passed, so this remains translated-host portability
+diagnostics and is not a Lance blocker.
 
 ## Nested-type and packaging matrix
 
@@ -160,38 +164,76 @@ coerced.
 
 | Candidate | Packaging and operational surface | Current state |
 | --- | --- | --- |
-| Parquet + DuckDB | Main spike JVM plus manifest-driven fixed-array restoration; replacement artifact for column evolution | survives corrected macOS gate with one physical-schema gap |
-| Lance | DuckDB native extension plus an isolated Lance Java/Arrow 18.3 helper | survives corrected macOS gate; native Ubuntu pending |
+| Parquet + DuckDB | Main spike JVM plus manifest-driven fixed-array restoration; replacement artifact for column evolution | passes native gates and is provisionally recommended |
+| Lance | DuckDB native extension plus an isolated Lance Java/Arrow 18.3 helper | passes native gates but fails the RSS and amplification decision thresholds |
 | Arrow IPC | Arrow 19 JDBC streaming | selected core interchange, not a durable table contract |
 | DuckTape | Pinned Git snapshot and matching native DuckDB library | optional TMD adapter only |
 
-## Gate 2 smoke and pending measurement
+## Gate 2 measurement
 
-A 16-row x 4-float smoke validates the measurement machinery only; it is not
-performance evidence. Parquet, Lance, and Arrow IPC all completed write, cold
-read, and applicable operations. Lance add preserved all 11,007 existing bytes,
-added 7,302 bytes, and rewrote 0 bytes. Lance replace preserved 18,296 bytes,
-added 9,592 bytes, and rewrote a 13-byte latest-version hint. The comparable
-Parquet artifacts were 3,425 source bytes, 3,680 add bytes, and 3,682 replace
-bytes. Every file was hashed before and after.
+[Native run 31258409578](https://github.com/velio-io/collet/actions/runs/31258409578)
+used 1,048,576 rows x 256 floats, exactly one GiB of logical embedding input,
+one warm-up, three measured executions, a 256 MiB DuckDB limit, JDBC streaming,
+one DuckDB worker, and 4,096-row Parquet row groups. Every format and cleanup
+case passed. The sort/join emitted 33,554,432 rows and spilled in every sample.
+The runner's OS page cache was not flushed.
 
-The required decision still needs native Linux AMD64 with a 256 MiB DuckDB
-limit, at least one GiB logical input, one warm-up, and three measured runs.
-The runner's OS page cache is not flushed. If native Gate 1 fails, Lance is
-rejected without running its expensive benchmark. If evidence is mixed, choose
-Parquet. Select Lance only if every hard gate passes and measured versioning and
-column-evolution benefit justifies its native/helper operational surface. The
-manual workflow defaults `run_benchmark` to false; Gate 2 requires a second,
-explicitly approved dispatch after reviewing the uploaded Gate 1 evidence.
+Median measured results:
+
+| Metric | Parquet | Lance | Lance / Parquet | Rule |
+| --- | ---: | ---: | ---: | --- |
+| Write latency | 12,558.66 ms | 6,586.41 ms | 0.524x | <= 1.20x, pass |
+| Full sequential latency | 3,761.14 ms | 2,636.81 ms | 0.701x | <= 1.20x, pass |
+| Projected/filtered latency | 95.51 ms | 94.71 ms | 0.992x | <= 1.20x, pass |
+| Sort/join latency | 5,856.63 ms | 6,264.31 ms | 1.070x | <= 1.20x, pass |
+| Process-cold latency | 3,993.13 ms | 2,834.96 ms | 0.710x | <= 1.20x, pass |
+| Process-cold peak RSS | 701,517,824 bytes | 1,452,331,008 bytes | 2.070x | <= 1.25x, fail |
+| Add changed/replacement bytes | 18,445,106 | 2,131,793,911 | 115.575x | <= 0.75x, fail |
+| Replace changed/replacement bytes | 18,787,184 | 2,131,796,225 | 113.471x | <= 0.75x, fail |
+
+Lance's median initial artifact was 1,169,049,750 bytes; Parquet's was
+15,295,724 bytes and Arrow IPC's was 1,282,662,386 bytes. The generated columns
+are deliberately repetitive, so this is evidence for this workload rather than
+a general compression claim. Lance's add/replace operations were faster than
+the Parquet replacements, but the working add/drop/cast sequence added roughly
+2.13 GB per change and its fresh helper process used twice Parquet's peak RSS.
+Those failures are sufficient to select Parquet under the approved rule.
+
+DuckDB 1.5.5 does not implement `EXPLAIN (ANALYZE, VERBOSE)`; its exact error is
+`Not implemented Error: Unimplemented explain type: verbose`. The spike records
+DuckDB's `all` fallback, containing logical, optimized, and physical plans.
+Parquet profiling reports read bytes for full and sort reads, while the Lance
+extension reports zero. These counters are retained as backend-visible evidence
+and are not presented as a comparable physical-byte measurement.
+
+Four earlier native runs were invalid instrumentation/workload iterations, not
+format decisions: JDBC result materialization, unnecessary ordering, a
+non-spillable wide sort, and Parquet's default row-group buffering during the
+double-width rewrite. Their run IDs, source hashes, and exact error strings are
+retained in `gate-2-linux-amd64.edn`. The final repair explicitly uses the
+existing 4,096-row batch size for every benchmark Parquet write; the approved
+rows, embedding width, memory limit, and repetition count were unchanged.
+
+The sanitized evidence is
+[`gate-1-linux-amd64.edn`](../../dev/spikes/issue-45/evidence/gate-1-linux-amd64.edn)
+and
+[`gate-2-linux-amd64.edn`](../../dev/spikes/issue-45/evidence/gate-2-linux-amd64.edn).
+Raw workflow artifacts remain outside Git, and no generated dataset binary was
+uploaded.
 
 ## Follow-ups
 
-- [tech.ml.dataset#389](https://github.com/techascent/tech.ml.dataset/issues/389): recommend DuckTape only as an optional object-column view. Its fixed-size
-  array gap and omitted top-level nil keys prevent it from defining Collet's
-  artifact contract.
-- **#46:** implement the supported nested Arrow boundary without assuming the
-  final durable format and without JSON coercion.
-- **#47:** keep task-local DuckDB SQL capable of scanning either surviving
-  artifact format until the native decision lands.
-- **#48:** keep artifact identity, manifests, publication, recovery, and
-  object-store behavior format-neutral until this ADR becomes accepted.
+- [tech.ml.dataset#389](https://github.com/techascent/tech.ml.dataset/issues/389):
+  keep Arrow IPC/JDBC Arrow as the integration boundary and offer DuckTape only
+  as an optional object-column view. Its fixed-size-array gap and omitted
+  top-level nil keys prevent it from defining Collet's artifact contract.
+- **#46:** define the nested JDBC Arrow boundary, including null parents, null
+  children, null list elements, maps, structs, lists, and fixed-size floats,
+  without JSON coercion; document Parquet's manifest-driven `FLOAT[n]` cast.
+- **#48:** implement format-neutral artifact and snapshot identities with a
+  Parquet/DuckDB storage adapter, immutable publication, checksums, recovery,
+  and object-store behavior. Do not copy Lance's internal version model into
+  the public contract.
+- **#47:** add task-local DuckDB SQL over the #48 Parquet artifacts with
+  projection/predicate pushdown, configurable bounded memory and spill, and
+  JDBC Arrow output.

--- a/docs/adr/0045-dataset-artifact-spike.md
+++ b/docs/adr/0045-dataset-artifact-spike.md
@@ -1,18 +1,23 @@
-# ADR 0045: Reopen the Lance decision with aligned runtimes
+# ADR 0045: Select Parquet for internal dataset artifacts
 
-Status: provisional pending review. No production artifact contract or
-publishable dependency is introduced by this spike.
+Status: accepted. No production artifact API or publishable dependency is
+introduced by this spike.
 
-## Provisional decision
+## Decision
 
-Recommend Parquet plus DuckDB for the durable artifact format. Lance passed
+Select Parquet plus DuckDB for Collet-owned durable artifacts. Lance passed
 every compatibility and recovery hard gate and met every latency threshold,
-but it failed the predetermined process-cold RSS and both rewrite-amplification
-thresholds. The recommendation remains provisional until review; this spike
-does not accept the format or start its production implementation.
+but it failed the predetermined process-cold RSS and both
+rewrite-amplification thresholds.
 
 JDBC Arrow 19 remains the default core interchange. DuckTape may only be an
 optional tech.ml.dataset view and never the artifact contract.
+
+This decision is scoped to internal immutable artifacts. Lance remains
+technically viable as a user-selected, long-lived destination whose native
+versions and incremental updates are part of the requested sink semantics;
+that optional integration is tracked in
+[#62](https://github.com/velio-io/collet/issues/62).
 
 The earlier Lance rejection was based on three invalid inferences:
 
@@ -164,8 +169,8 @@ coerced.
 
 | Candidate | Packaging and operational surface | Current state |
 | --- | --- | --- |
-| Parquet + DuckDB | Main spike JVM plus manifest-driven fixed-array restoration; replacement artifact for column evolution | passes native gates and is provisionally recommended |
-| Lance | DuckDB native extension plus an isolated Lance Java/Arrow 18.3 helper | passes native gates but fails the RSS and amplification decision thresholds |
+| Parquet + DuckDB | Main spike JVM plus manifest-driven fixed-array restoration; replacement artifact for column evolution | selected for Collet-owned durable artifacts |
+| Lance | DuckDB native extension plus an isolated Lance Java/Arrow 18.3 helper | not selected internally; optional destination tracked in #62 |
 | Arrow IPC | Arrow 19 JDBC streaming | selected core interchange, not a durable table contract |
 | DuckTape | Pinned Git snapshot and matching native DuckDB library | optional TMD adapter only |
 
@@ -196,8 +201,9 @@ Lance's median initial artifact was 1,169,049,750 bytes; Parquet's was
 are deliberately repetitive, so this is evidence for this workload rather than
 a general compression claim. Lance's add/replace operations were faster than
 the Parquet replacements, but the working add/drop/cast sequence added roughly
-2.13 GB per change and its fresh helper process used twice Parquet's peak RSS.
-Those failures are sufficient to select Parquet under the approved rule.
+2.13 GB per change. The fresh benchmark JVM scanning Lance through the DuckDB
+extension reached twice Parquet's process-cold peak RSS. Those failures select
+Parquet under the approved rule.
 
 DuckDB 1.5.5 does not implement `EXPLAIN (ANALYZE, VERBOSE)`; its exact error is
 `Not implemented Error: Unimplemented explain type: verbose`. The spike records
@@ -237,3 +243,6 @@ uploaded.
 - **#47:** add task-local DuckDB SQL over the #48 Parquet artifacts with
   projection/predicate pushdown, configurable bounded memory and spill, and
   JDBC Arrow output.
+- **#62:** define Lance as an optional destination with explicit commit,
+  idempotency, version-pinning, retention, and packaging semantics. It must not
+  replace the Parquet internal artifact contract.


### PR DESCRIPTION
## Outcome

Accepts Parquet plus DuckDB for Collet-owned durable artifacts from the
completed native Gate 1 and Gate 2 evidence.

Lance passed every compatibility and recovery hard gate and all five latency
limits. It did not pass the predetermined internal-artifact resource and
rewrite-amplification rules:

- process-cold peak RSS: 2.070x Parquet, limit 1.25x
- add changed bytes: 115.575x the Parquet replacement, limit 0.75x
- replace changed bytes: 113.471x the Parquet replacement, limit 0.75x

JDBC Arrow remains the core interchange. DuckTape remains an optional TMD view
only. Lance remains technically viable as a user-selected destination and is
tracked separately in #62; it is not the internal artifact contract.

## Native evidence

- Gate 1: https://github.com/velio-io/collet/actions/runs/31255915266
- Gate 2: https://github.com/velio-io/collet/actions/runs/31258409578
- Linux AMD64, JDK 25.0.3
- direct, LocalStack S3, and offline Docker checks pass
- exactly 1 GiB logical input, one warm-up, and three measured samples
- every final format operation, cleanup, schema/evolution check, and spill
  check passes
- raw workflow artifacts remain outside Git; generated dataset binaries were
  not uploaded

Four invalid instrumentation/workload runs and their exact errors remain in the
sanitized EDN. The repairs stream JDBC results, isolate a spillable sort
workload, and bound Parquet writes to the existing 4,096-row batch size; the
approved benchmark inputs were not changed.

## Scope

- isolated development spike and sanitized evidence
- accepted ADR 0045 and COLLET_NEXT decision
- no production artifact API, package dependency, generated POM, root README
  claim, or issue-body change
- no implementation work started on #46, #48, or #47
- Lance destination work is isolated in #62

## Validation

- native Gate 1 and Gate 2 workflow: pass
- benchmark smoke: pass
- spike formatting: pass
- unit and integration tests: pass
- artifact verification: pass
- release plan: no additional publishable package selected
- documentation links and git diff check: pass

Closes #45.
