### PR TITLE
feat: support nested and extended Arrow results

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,17 @@ By default, data returned from tasks will be offloaded to Arrow files. These fil
 into the JVM heap) and represented as [TMD datasets](https://github.com/techascent/tech.ml.dataset?tab=readme-ov-file)
 or dataset sequences when data is required for processing.
 
-**Note!** Currently, not all types of data can be offloaded to Arrow. It works for collections with simple types like
-strings, numbers, dates, etc., and for lists with simple values.
-Nested data structures like maps aren't supported yet but will be in future releases. Collections that can't be
-converted to Arrow will be kept in memory.
+Nested values can be offloaded through Arrow when task-result metadata supplies
+an explicit :arrow-columns schema. Supported shapes include fixed Structs,
+dynamic UTF-8 Maps, Lists including List<Struct>, fixed Float32 embeddings,
+and exact decimals. Arrow remains the schema authority; ambiguous values such
+as an ordinary Clojure map require that metadata rather than guessing whether
+they are a Struct or Map.
+
+Scalar-only results remain memory-mapped. Nested values are exposed as TMD
+object columns one Arrow record batch at a time, so only the requested bounded
+batch is copied to JVM heap. See [the Arrow boundary guide](./docs/arrow.md)
+for the schema grammar, batching, decimal, Java Time, and error rules.
 
 You can disable this feature by setting the `:use-arrow` key to false in the pipeline specification.
 

--- a/collet-action-http/test/collet/actions/http_test.clj
+++ b/collet-action-http/test/collet/actions/http_test.clj
@@ -1,16 +1,16 @@
 (ns collet.actions.http-test
   (:require
    [clojure.test :refer :all]
-   [collet.core :as collet]
    [collet.actions.http :as sut]
-   [collet.test-http-server :as http]
+   [collet.core :as collet]
    [collet.test-fixtures :as tf]
+   [collet.test-http-server :as http]
    [tech.v3.dataset :as ds]))
 
 
 (use-fixtures :once
-  http/with-server
-  (tf/instrument! 'collet.actions.http))
+              http/with-server
+              (tf/instrument! 'collet.actions.http))
 
 
 (deftest http-request-test
@@ -55,79 +55,80 @@
   (let [events  (atom [])
         artists (atom [])]
     (testing "extracting a list of events with pagination"
-      (let [pipeline-spec {:name  :city-events
-                           :tasks [{:name         :area-events
-                                    :keep-state   true
-                                    :state-format :flatten
-                                    :setup        [{:type      :clj/format
-                                                    :name      :area-query
-                                                    :selectors {'city [:config :city]}
-                                                    :params    ["area:%s AND type:City" 'city]}
-                                                   {:type      :collet.actions.http/request
-                                                    :name      :area-request
-                                                    :selectors {'area-query [:state :area-query]}
-                                                    :params    {:url          (http/musicbrainz-url "/area")
-                                                                :accept       :json
-                                                                :as           :json
-                                                                :query-params {:limit 1
-                                                                               :query 'area-query}}
-                                                    :return    [:body :areas [:$/cat :id]]}
-                                                   {:type      :clj/ffirst
-                                                    :name      :area-id
-                                                    :selectors '{area-ids [:state :area-request]}
-                                                    :params    '[area-ids]}
-                                                   {:type      :clj/format
-                                                    :name      :events-query
-                                                    :selectors '{area-id [:state :area-id]}
-                                                    :params    ["aid:%s AND type:Concert" 'area-id]}]
-                                    :actions      [{:type      :collet.actions.http/request
-                                                    :name      :events-request
-                                                    :selectors {'events-query [:state :events-query]}
-                                                    :params    {:url          (http/musicbrainz-url "/event")
-                                                                :accept       :json
-                                                                :as           :json
-                                                                :query-params {:limit  10
-                                                                               :offset 0
-                                                                               :query  'events-query}}
-                                                    :return    [:body :events]}]
+      (let [pipeline-spec         {:name      :city-events
+                                   :use-arrow false
+                                   :tasks     [{:name         :area-events
+                                                :keep-state   true
+                                                :state-format :flatten
+                                                :setup        [{:type      :clj/format
+                                                                :name      :area-query
+                                                                :selectors {'city [:config :city]}
+                                                                :params    ["area:%s AND type:City" 'city]}
+                                                               {:type      :collet.actions.http/request
+                                                                :name      :area-request
+                                                                :selectors {'area-query [:state :area-query]}
+                                                                :params    {:url          (http/musicbrainz-url "/area")
+                                                                            :accept       :json
+                                                                            :as           :json
+                                                                            :query-params {:limit 1
+                                                                                           :query 'area-query}}
+                                                                :return    [:body :areas [:$/cat :id]]}
+                                                               {:type      :clj/ffirst
+                                                                :name      :area-id
+                                                                :selectors '{area-ids [:state :area-request]}
+                                                                :params    '[area-ids]}
+                                                               {:type      :clj/format
+                                                                :name      :events-query
+                                                                :selectors '{area-id [:state :area-id]}
+                                                                :params    ["aid:%s AND type:Concert" 'area-id]}]
+                                                :actions      [{:type      :collet.actions.http/request
+                                                                :name      :events-request
+                                                                :selectors {'events-query [:state :events-query]}
+                                                                :params    {:url          (http/musicbrainz-url "/event")
+                                                                            :accept       :json
+                                                                            :as           :json
+                                                                            :query-params {:limit  10
+                                                                                           :offset 0
+                                                                                           :query  'events-query}}
+                                                                :return    [:body :events]}]
 
-                                    :iterator     {:next false}
-                                    :return       [:state :events-request]}]}
-            pipeline      (collet/compile-pipeline pipeline-spec)
-            run           (tf/run-pipeline! pipeline {:city "London"})
+                                                :iterator     {:next false}
+                                                :return       [:state :events-request]}]}
+            pipeline              (collet/compile-pipeline pipeline-spec)
+            run                   (tf/run-pipeline! pipeline {:city "London"})
             {:keys [area-events]} run]
         (is (= (count area-events) 10))
         (reset! events area-events)))
 
     (testing "extracting all artists from events"
-      (let [pipeline-spec           {:name  :city-events-artists
-                                     :tasks [{:name       :event-artists-rating
-                                              :keep-state true
-                                              :setup      [{:type      :slicer
-                                                            :name      :event-artists
-                                                            :selectors {'events [:config :events]}
-                                                            :params    {:sequence 'events
-                                                                        :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
-                                              :actions    [{:type      :mapper
-                                                            :name      :event-artist-item
-                                                            :selectors {'event-artists [:state :event-artists]}
-                                                            :params    {:sequence 'event-artists}}
-                                                           {:type      :collet.actions.http/request
-                                                            :name      :artist-details
-                                                            :when      [:not-nil? [:$mapper/item :artist]]
-                                                            :selectors {'artist-id [:$mapper/item :artist :id]}
-                                                            :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
-                                                                        :accept       :json
-                                                                        :as           :json
-                                                                        :query-params {:inc "ratings"}}
-                                                            :return    [:body]}]
-                                              :iterator   {:next [:true? [:$mapper/has-next-item]]}
-                                              :return     [{:artist-rate [:state :artist-details :rating :value]
-                                                            :event-id    [:$mapper/item :id]}]}]}
+      (let [pipeline-spec           {:name      :city-events-artists
+                                     :use-arrow false
+                                     :tasks     [{:name       :event-artists-rating
+                                                  :keep-state true
+                                                  :setup      [{:type      :slicer
+                                                                :name      :event-artists
+                                                                :selectors {'events [:config :events]}
+                                                                :params    {:sequence 'events
+                                                                            :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
+                                                  :actions    [{:type      :mapper
+                                                                :name      :event-artist-item
+                                                                :selectors {'event-artists [:state :event-artists]}
+                                                                :params    {:sequence 'event-artists}}
+                                                               {:type      :collet.actions.http/request
+                                                                :name      :artist-details
+                                                                :when      [:not-nil? [:$mapper/item :artist]]
+                                                                :selectors {'artist-id [:$mapper/item :artist :id]}
+                                                                :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
+                                                                            :accept       :json
+                                                                            :as           :json
+                                                                            :query-params {:inc "ratings"}}
+                                                                :return    [:body]}]
+                                                  :iterator   {:next [:true? [:$mapper/has-next-item]]}
+                                                  :return     [{:artist-rate [:state :artist-details :rating :value]
+                                                                :event-id    [:$mapper/item :id]}]}]}
             pipeline                (collet/compile-pipeline pipeline-spec)
             run                     (tf/run-pipeline! pipeline {:events @events})
             {:keys [event-artists-rating]} run
-            event-artists-rating-ds (first (collet/arrow->dataset event-artists-rating))
             events-with-artists-num (->> (mapcat :relations @events)
                                          (filter (comp identity :artist))
                                          (count))
@@ -136,39 +137,50 @@
                                                    (not (some (comp identity :artist) relations))))
                                          (count))]
         (is (= (+ events-with-artists-num events-no-artists-num)
-               (ds/row-count event-artists-rating-ds)))
-        (reset! artists (ds/rows event-artists-rating-ds))))
+               (count event-artists-rating)))
+        (reset! artists (vec event-artists-rating))))
 
     (testing "combining artists ratings with events"
-      (let [pipeline-spec  {:name  :city-events-artists
-                            :tasks [{:name       :best-events
-                                     :keep-state true
-                                     :setup      [{:type      :slicer
-                                                   :name      :events-ratings
-                                                   :selectors {'artists [:config :artists]}
-                                                   :params    {:sequence 'artists
-                                                               :apply    [[:fold {:by [:event-id]}]]}}]
-                                     :actions    [{:type      :mapper
-                                                   :name      :event-rating
-                                                   :selectors {'ratings [:state :events-ratings]}
-                                                   :params    {:sequence 'ratings}}
-                                                  {:type      :custom
-                                                   :name      :calculated-rating
-                                                   :selectors {'event-ratings [:$mapper/item]}
-                                                   :params    ['event-ratings]
-                                                   :fn        '(fn [{:keys [event-id artist-rate]}]
-                                                                 (let [rating (if (seq artist-rate)
-                                                                                (double (/ (apply + artist-rate)
-                                                                                           (count artist-rate)))
-                                                                                0)]
-                                                                   {:event-id event-id
-                                                                    :rating   rating}))}]
-                                     :iterator   {:next [:true? [:$mapper/has-next-item]]}
-                                     :return     [:state :calculated-rating]}]}
-            pipeline       (collet/compile-pipeline pipeline-spec)
-            run            (tf/run-pipeline! pipeline {:artists @artists})
-            {:keys [best-events]} run
-            best-events-ds (first (collet/arrow->dataset best-events))]
+      (let
+        [pipeline-spec
+         {:name :city-events-artists
+          :tasks
+          [{:name :best-events
+            :keep-state true
+            :setup [{:type      :slicer
+                     :name      :events-ratings
+                     :selectors {'artists [:config :artists]}
+                     :params    {:sequence 'artists
+                                 :apply    [[:fold {:by [:event-id]}]]}}]
+            :actions
+            [{:type      :mapper
+              :name      :event-rating
+              :selectors {'ratings [:state :events-ratings]}
+              :params    {:sequence 'ratings}}
+             {:type :custom
+              :name :calculated-rating
+              :selectors {'event-ratings [:$mapper/item]}
+              :params ['event-ratings]
+              :fn
+              '(fn
+                [{:keys [event-id artist-rate]}]
+                (let
+                 [rating
+                  (if
+                   (seq artist-rate)
+                   (double
+                    (/
+                     (apply + artist-rate)
+                     (count artist-rate)))
+                   0)]
+                 {:event-id event-id
+                  :rating   rating}))}]
+            :iterator {:next [:true? [:$mapper/has-next-item]]}
+            :return [:state :calculated-rating]}]}
+         pipeline (collet/compile-pipeline pipeline-spec)
+         run (tf/run-pipeline! pipeline {:artists @artists})
+         {:keys [best-events]} run
+         best-events-ds (first (collet/arrow->dataset best-events))]
         (is (every? #(contains? % :rating) (ds/rows best-events-ds))
             "All events should have a rating")
 
@@ -179,101 +191,115 @@
 
 (deftest pipeline-complex-http-flow-test
   (testing "complex pipeline to extract artists"
-    (let [pipeline-spec {:name      :city-best-events
-                         :use-arrow false
-                         :tasks     [{:name         :area-events
-                                      :state-format :flatten
-                                      :setup        [{:type      :clj/format
-                                                      :name      :area-query
-                                                      :selectors {'city [:config :city]}
-                                                      :params    ["area:%s AND type:City" 'city]}
-                                                     {:type      :collet.actions.http/request
-                                                      :name      :area-request
-                                                      :selectors {'area-query [:state :area-query]}
-                                                      :params    {:url          (http/musicbrainz-url "/area")
-                                                                  :accept       :json
-                                                                  :as           :json
-                                                                  :query-params {:limit 1
-                                                                                 :query 'area-query}}
-                                                      :return    [:body :areas [:$/cat :id]]}
-                                                     {:type      :clj/first
-                                                      :name      :area-id
-                                                      :selectors '{area-ids [:state :area-request]}
-                                                      :params    '[area-ids]}
-                                                     {:type      :clj/format
-                                                      :name      :events-query
-                                                      :selectors '{area-id [:state :area-id]}
-                                                      :params    ["aid:%s AND type:Concert" 'area-id]}]
-                                      :actions      [{:type :counter
-                                                      :name :req-count}
-                                                     {:type      :clj/*
-                                                      :name      :offset
-                                                      :selectors {'req-count [:state :req-count]}
-                                                      :params    ['req-count 10]}
-                                                     {:type      :collet.actions.http/request
-                                                      :name      :events-request
-                                                      :selectors {'events-query [:state :events-query]
-                                                                  'offset       [:state :offset]}
-                                                      :params    {:url          (http/musicbrainz-url "/event")
-                                                                  :accept       :json
-                                                                  :as           :json
-                                                                  :query-params {:limit  10
-                                                                                 :offset 'offset
-                                                                                 :query  'events-query}}
-                                                      :return    [:body :events]}]
-                                      :iterator     {:next [:< [:state :req-count] 3]}}
+    (let
+      [pipeline-spec
+       {:name :city-best-events
+        :use-arrow false
+        :tasks
+        [{:name         :area-events
+          :state-format :flatten
+          :setup        [{:type      :clj/format
+                          :name      :area-query
+                          :selectors {'city [:config :city]}
+                          :params    ["area:%s AND type:City" 'city]}
+                         {:type      :collet.actions.http/request
+                          :name      :area-request
+                          :selectors {'area-query [:state :area-query]}
+                          :params    {:url          (http/musicbrainz-url "/area")
+                                      :accept       :json
+                                      :as           :json
+                                      :query-params {:limit 1
+                                                     :query 'area-query}}
+                          :return    [:body :areas [:$/cat :id]]}
+                         {:type      :clj/first
+                          :name      :area-id
+                          :selectors '{area-ids [:state :area-request]}
+                          :params    '[area-ids]}
+                         {:type      :clj/format
+                          :name      :events-query
+                          :selectors '{area-id [:state :area-id]}
+                          :params    ["aid:%s AND type:Concert" 'area-id]}]
+          :actions      [{:type :counter
+                          :name :req-count}
+                         {:type      :clj/*
+                          :name      :offset
+                          :selectors {'req-count [:state :req-count]}
+                          :params    ['req-count 10]}
+                         {:type      :collet.actions.http/request
+                          :name      :events-request
+                          :selectors {'events-query [:state :events-query]
+                                      'offset       [:state :offset]}
+                          :params    {:url          (http/musicbrainz-url "/event")
+                                      :accept       :json
+                                      :as           :json
+                                      :query-params {:limit  10
+                                                     :offset 'offset
+                                                     :query  'events-query}}
+                          :return    [:body :events]}]
+          :iterator     {:next [:< [:state :req-count] 3]}}
 
-                                     {:name     :events-with-artists
-                                      :inputs   [:area-events]
-                                      :setup    [{:type      :slicer
-                                                  :name      :event-artists
-                                                  :selectors {'events [:inputs :area-events]}
-                                                  :params    {:sequence 'events
-                                                              :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
-                                      :actions  [{:type      :enrich
-                                                  :name      :artist-details
-                                                  :target    [:state :event-artists]
-                                                  :when      [:not-nil? [:$enrich/item :artist :id]]
-                                                  :action    :collet.actions.http/request
-                                                  :selectors {'artist-id [:$enrich/item :artist :id]}
-                                                  :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
-                                                              :accept       :json
-                                                              :as           :json
-                                                              :query-params {:inc "ratings"}}
-                                                  :return    [:body]
-                                                  :fold-in   [:artist]}]
-                                      :iterator {:next [:true? [:$enrich/has-next-item]]}}
+         {:name     :events-with-artists
+          :inputs   [:area-events]
+          :setup    [{:type      :slicer
+                      :name      :event-artists
+                      :selectors {'events [:inputs :area-events]}
+                      :params    {:sequence 'events
+                                  :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
+          :actions  [{:type      :enrich
+                      :name      :artist-details
+                      :target    [:state :event-artists]
+                      :when      [:not-nil? [:$enrich/item :artist :id]]
+                      :action    :collet.actions.http/request
+                      :selectors {'artist-id [:$enrich/item :artist :id]}
+                      :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
+                                  :accept       :json
+                                  :as           :json
+                                  :query-params {:inc "ratings"}}
+                      :return    [:body]
+                      :fold-in   [:artist]}]
+          :iterator {:next [:true? [:$enrich/has-next-item]]}}
 
-                                     {:name       :rated-events
-                                      :keep-state true
-                                      :inputs     [:events-with-artists]
-                                      :setup      [{:type      :slicer
-                                                    :name      :events-with-ratings
-                                                    :selectors {'events [:inputs :events-with-artists]}
-                                                    :params    {:sequence 'events
-                                                                :apply    [[:fold {:by            :id
-                                                                                   :rollup        [:artist]
-                                                                                   :rollup-except true}]]}}]
-                                      :actions    [{:type      :mapper
-                                                    :name      :event-rating
-                                                    :selectors {'ratings [:state :events-with-ratings]}
-                                                    :params    {:sequence 'ratings}}
-                                                   {:type      :custom
-                                                    :name      :event-with-rating
-                                                    :selectors {'event-ratings [:$mapper/item]}
-                                                    :params    ['event-ratings]
-                                                    :fn        '(fn [{:keys [artist] :as event}]
-                                                                  (let [ratings (->> artist
-                                                                                     (map (comp :value :rating))
-                                                                                     (filter number?))
-                                                                        rating  (if (seq ratings)
-                                                                                  (double (/ (apply + ratings)
-                                                                                             (count ratings)))
-                                                                                  0)]
-                                                                    (assoc event :rating rating)))}]
-                                      :iterator   {:next [:true? [:$mapper/has-next-item]]}}]}
-          pipeline      (collet/compile-pipeline pipeline-spec)
-          run           (tf/run-pipeline! pipeline {:city "London"})]
+         {:name :rated-events
+          :keep-state true
+          :inputs [:events-with-artists]
+          :setup [{:type      :slicer
+                   :name      :events-with-ratings
+                   :selectors {'events [:inputs :events-with-artists]}
+                   :params    {:sequence 'events
+                               :apply    [[:fold
+                                           {:by            :id
+                                            :rollup        [:artist]
+                                            :rollup-except true}]]}}]
+          :actions
+          [{:type      :mapper
+            :name      :event-rating
+            :selectors {'ratings [:state :events-with-ratings]}
+            :params    {:sequence 'ratings}}
+           {:type :custom
+            :name :event-with-rating
+            :selectors {'event-ratings [:$mapper/item]}
+            :params ['event-ratings]
+            :fn
+            '(fn
+              [{:keys [artist] :as event}]
+              (let
+               [ratings
+                (->>
+                 artist
+                 (map (comp :value :rating))
+                 (filter number?))
+                rating
+                (if
+                 (seq ratings)
+                 (double
+                  (/
+                   (apply + ratings)
+                   (count ratings)))
+                 0)]
+               (assoc event :rating rating)))}]
+          :iterator {:next [:true? [:$mapper/has-next-item]]}}]}
+       pipeline (collet/compile-pipeline pipeline-spec)
+       run (tf/run-pipeline! pipeline {:city "London"})]
 
       (let [{:keys [area-events events-with-artists rated-events]} run
             events-with-artists-num (->> (mapcat :relations area-events)
@@ -293,7 +319,10 @@
         (is (every? #(contains? % :artist) events-with-artists)
             "all artists should have an artist field")
 
-        (is (= (->> area-events (map :id) (distinct) (count)) ;; sometimes API returns same events in different pages
+        (is (= (->> area-events
+                    (map :id)
+                    (distinct)
+                    (count)) ;; sometimes API returns same events in different pages
                (count rated-events))
             "should match the number of events fetched in the first step")
 

--- a/collet-action-jdbc/src/collet/actions/jdbc.clj
+++ b/collet-action-jdbc/src/collet/actions/jdbc.clj
@@ -1,22 +1,22 @@
 (ns collet.actions.jdbc
   (:require
-   [clojure.java.io :as io]
    [charred.api :as charred]
-   [next.jdbc :as jdbc]
-   [next.jdbc.result-set :as rs]
-   [next.jdbc.connection :as connection]
-   [next.jdbc.date-time :as date-time]
-   [honey.sql :as sql]
+   [clojure.java.io :as io]
    [collet.action :as action]
    [collet.arrow :as arrow]
    [collet.utils :as utils]
+   [honey.sql :as sql]
+   [next.jdbc :as jdbc]
+   [next.jdbc.connection :as connection]
+   [next.jdbc.date-time :as date-time]
+   [next.jdbc.result-set :as rs]
    [tech.v3.dataset :as ds])
   (:import
-   [clojure.lang ILookup]
-   [java.io Closeable File Writer]
-   [java.util Arrays Locale]
-   [java.sql Array Clob Connection ResultSet ResultSetMetaData SQLFeatureNotSupportedException Time Types]
-   [java.time Duration LocalDate LocalDateTime LocalTime]))
+    [clojure.lang ILookup]
+    [java.io Closeable File Writer]
+    [java.util Arrays Locale]
+    [java.sql Array Clob Connection ResultSet ResultSetMetaData SQLFeatureNotSupportedException Time Types]
+    [java.time Duration LocalDate LocalDateTime LocalTime]))
 
 
 ;; next.jdbc.types namespace exports the following functions to convert Clojure types to SQL types:
@@ -27,32 +27,33 @@
 ;; as-nvarchar as-longnvarchar as-nclob as-sqlxml as-ref-cursor as-time-with-timezone
 ;; as-timestamp-with-timezone
 
+
 ;; convert SQL dates and timestamps to local time automatically
 (date-time/read-as-local)
 
 
 (extend-protocol rs/ReadableColumn
-  Time
-  (read-column-by-label [^Time v _]
-    (.toLocalTime v))
-  (read-column-by-index [^Time v _2 _3]
-    (.toLocalTime v)))
+ Time
+ (read-column-by-label [^Time v _]
+   (.toLocalTime v))
+ (read-column-by-index [^Time v _2 _3]
+   (.toLocalTime v)))
 
 
 (extend-protocol rs/ReadableColumn
-  Array
-  (read-column-by-label [^Array v _]
-    (vec (.getArray v)))
-  (read-column-by-index [^Array v _ _]
-    (vec (.getArray v))))
+ Array
+ (read-column-by-label [^Array v _]
+   (vec (.getArray v)))
+ (read-column-by-index [^Array v _ _]
+   (vec (.getArray v))))
 
 
 (extend-protocol rs/ReadableColumn
-  Clob
-  (read-column-by-label [^Clob v _]
-    (rs/clob->string v))
-  (read-column-by-index [^Clob v _2 _3]
-    (rs/clob->string v)))
+ Clob
+ (read-column-by-label [^Clob v _]
+   (rs/clob->string v))
+ (read-column-by-index [^Clob v _2 _3]
+   (rs/clob->string v)))
 
 
 (defn append-row-to-file
@@ -102,7 +103,7 @@
   "Returns a map of column names and their SQL types."
   [^ResultSet row prefix-table?]
   (let [^ResultSetMetaData md (rs/metadata row)]
-    (->> (for [i (range 1 (inc (.getColumnCount md)))
+    (->> (for [i    (range 1 (inc (.getColumnCount md)))
                :let [maybe-table-name (try (.getTableName md i)
                                            (catch SQLFeatureNotSupportedException _ nil))
                      table-name       (when (some? maybe-table-name)
@@ -127,7 +128,8 @@
                           :or   {auto-commit false}} connection]
                      (-> {:jdbcUrl     (connection/jdbc-url connection)
                           :auto-commit auto-commit}
-                         (utils/assoc-some :user user :password password)
+                         (utils/assoc-some :user user
+                                           :password password)
                          (jdbc/get-datasource)))
 
                    :else connection)]
@@ -161,31 +163,33 @@
       (set! column-types (get-columns-types record prefix-table?)))
     (aset batch size (record->map record))
     (set! size (inc size))
-   ;; flush the batch if it's full
+    ;; flush the batch if it's full
     (when (= (alength batch) size)
       (flush-batch this batch)))
 
   (flush-batch [this batch-out]
-   ;; check if convertable to arrow
-    (when (nil? arrow?)       ;; we completed the first batch
+    ;; check if convertable to arrow
+    (when (nil? arrow?) ;; we completed the first batch
       (if-let [batch-arrow-columns (arrow/get-columns batch-out)]
         ;; arrow pathway
         (do (set! arrow? true)
             (set! arrow-columns batch-arrow-columns)
-            (set! file (doto (File/createTempFile "jdbc-query-data" ".arrow")
-                         (.deleteOnExit)))
+            (set! file
+                  (doto (File/createTempFile "jdbc-query-data" ".arrow")
+                    (.deleteOnExit)))
             (set! writer (collet.arrow/make-writer file arrow-columns)))
         ;; json pathway
         (do (set! arrow? false)
-            (set! file (doto (File/createTempFile "jdbc-query-data" ".json")
-                         (.deleteOnExit)))
+            (set! file
+                  (doto (File/createTempFile "jdbc-query-data" ".json")
+                    (.deleteOnExit)))
             (set! writer (io/writer file :append true)))))
-   ;; write to file (arrow or json) based on the previous check
+    ;; write to file (arrow or json) based on the previous check
     (if arrow?
       (collet.arrow/write writer batch-out)
       (doseq [record batch-out]
         (append-row-to-file writer record)))
-   ;; clear the batch
+    ;; clear the batch
     (set! size 0)
     (^[Object/1 Object] Arrays/fill batch nil))
 
@@ -213,7 +217,14 @@
 (defn ->batch-result
   ^BatchResult [batch-size prefix-table?]
   (->BatchResult
-   (object-array batch-size) prefix-table? 0 nil nil nil nil nil))
+   (object-array batch-size)
+   prefix-table?
+   0
+   nil
+   nil
+   nil
+   nil
+   nil))
 
 
 (def query-params-spec
@@ -261,14 +272,14 @@
                            (sql/format query options)
                            query)
             options      (utils/assoc-some
-                           {:concurrency concurrency
-                            :result-type result-type
-                            :cursors     cursors
-                            :fetch-size  fetch-size
-                            :builder-fn  (if (not prefix-table?)
-                                           rs/as-unqualified-lower-maps
-                                           rs/as-lower-maps)}
-                           :timeout timeout)]
+                          {:concurrency concurrency
+                           :result-type result-type
+                           :cursors     cursors
+                           :fetch-size  fetch-size
+                           :builder-fn  (if (not prefix-table?)
+                                          rs/as-unqualified-lower-maps
+                                          rs/as-lower-maps)}
+                          :timeout timeout)]
         (->> (jdbc/plan conn query-string options)
              (run! #(append batch %)))))
 
@@ -278,7 +289,11 @@
     (cond
       ;; no files were written, return the result set as a sequence of maps
       (nil? (:file batch))
-      (take (:size batch) (:batch batch))
+      (let [records (take (:size batch) (:batch batch))]
+        (if-let [columns (arrow/get-columns records)]
+          (with-meta records {:arrow-columns columns})
+          ;; Dynamic JSON values remain on the action's existing fallback path.
+          (with-meta records {:collet.arrow/skip-conversion? true})))
 
       (:arrow? batch)
       (collet.arrow/read-dataset (:file batch) (:arrow-columns batch))
@@ -291,10 +306,14 @@
                              identity)
             cleanup-fn     #(do (.close reader)
                                 (.delete ^File (:file batch)))]
-        (->rows-seq lines row-mapping-fn cleanup-fn)))))
+        ;; Do not reinterpret a deliberate JDBC JSON fallback as a core schema error.
+        (with-meta
+          (->rows-seq lines row-mapping-fn cleanup-fn)
+          {:collet.arrow/skip-conversion? true})))))
 
 
-(defmethod action/action-fn ::query [_]
+(defmethod action/action-fn ::query
+  [_]
   make-query)
 
 
@@ -343,12 +362,13 @@
                              (sql/format options))
                          statement)
           options      (utils/assoc-some
-                         {:builder-fn (if (not prefix-table?)
-                                        rs/as-unqualified-lower-maps
-                                        rs/as-lower-maps)}
-                         :timeout timeout)]
+                        {:builder-fn (if (not prefix-table?)
+                                       rs/as-unqualified-lower-maps
+                                       rs/as-lower-maps)}
+                        :timeout timeout)]
       (jdbc/execute! conn query-string options))))
 
 
-(defmethod action/action-fn ::execute [_]
+(defmethod action/action-fn ::execute
+  [_]
   execute-statement)

--- a/collet-action-jdbc/test/collet/actions/jdbc_test.clj
+++ b/collet-action-jdbc/test/collet/actions/jdbc_test.clj
@@ -1,18 +1,18 @@
 (ns collet.actions.jdbc-test
   (:require
-   [clojure.test :refer :all]
-   [next.jdbc :as jdbc]
    [clj-test-containers.core :as tc]
-   [collet.test-containers :as containers]
-   [collet.test-fixtures :as tf]
+   [clojure.test :refer :all]
+   [collet.actions.jdbc :as sut]
    [collet.core :as collet]
    [collet.deps :as collet.deps]
+   [collet.test-containers :as containers]
+   [collet.test-fixtures :as tf]
    [collet.utils :as utils]
-   [collet.actions.jdbc :as sut]
+   [next.jdbc :as jdbc]
    [tech.v3.dataset :as ds])
   (:import
-   [clojure.lang LazySeq]
-   [java.time LocalDate LocalDateTime LocalTime Duration]))
+    [clojure.lang LazySeq]
+    [java.time LocalDate LocalDateTime LocalTime Duration]))
 
 
 (use-fixtures :once (tf/instrument! 'collet.actions.jdbc))
@@ -164,7 +164,9 @@
 (defn populate-pg-data-types [conn]
   ;; create enum type
   (jdbc/execute! conn ["CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')"])
-  (jdbc/execute! conn ["CREATE TABLE data_types (id SERIAL PRIMARY KEY,
+  (jdbc/execute!
+   conn
+   ["CREATE TABLE data_types (id SERIAL PRIMARY KEY,
                                                  bool_col BOOLEAN,
                                                  int_col INT,
                                                  float_col FLOAT,
@@ -176,15 +178,21 @@
                                                  jsonb_col JSONB,
                                                  interval_col INTERVAL,
                                                  mood_col mood)"])
-  (jdbc/execute! conn ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
+  (jdbc/execute!
+   conn
+   ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
                         VALUES (true, 42, 3.14, 'text', '2024-04-22', '21:01:03', '2024-04-22 21:01:03', '{\"a\": 1}', '{\"b\": 2}', '1 day 2 hours 3 minutes 4 seconds', 'happy')"])
-  (jdbc/execute! conn ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
+  (jdbc/execute!
+   conn
+   ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
                         VALUES (false, 43, 3.15, 'text2', '2024-04-23', '21:01:04', '2024-04-23 21:01:04', '{\"c\": 3}', '{\"d\": 4}', '2 days 3 hours 4 minutes 5 seconds', 'sad')"]))
 
 
 (defn add-more-rows [conn]
   (dotimes [_i 20]
-    (jdbc/execute! conn ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
+    (jdbc/execute!
+     conn
+     ["INSERT INTO data_types (bool_col, int_col, float_col, text_col, date_col, time_col, timestamp_col, json_col, jsonb_col, interval_col, mood_col)
                           VALUES (true, 42, 3.14, 'text', '2024-04-22', '21:01:03', '2024-04-22 21:01:03', '{\"a\": 1}', '{\"b\": 2}', '1 day 2 hours 3 minutes 4 seconds', 'happy')"])))
 
 
@@ -215,31 +223,32 @@
                                                                        :from   :data-types}}}]}]})
             run      (tf/run-pipeline! pipeline {:connection connection-map})
             result   (:query run)]
-        (is (= (list #:data_types{:bool_col      true
-                                  :date_col      (LocalDate/parse "2024-04-22")
-                                  :float_col     3.14
-                                  :id            1
-                                  :int_col       42
-                                  :interval_col  (Duration/parse "PT26H3M4S")
-                                  :json_col      {:a 1}
-                                  :jsonb_col     {:b 2}
-                                  :mood_col      "happy"
-                                  :text_col      "text"
-                                  :time_col      (LocalTime/parse "21:01:03")
-                                  :timestamp_col (LocalDateTime/parse "2024-04-22T21:01:03")}
-                     #:data_types{:bool_col      false
-                                  :date_col      (LocalDate/parse "2024-04-23")
-                                  :float_col     3.15
-                                  :id            2
-                                  :int_col       43
-                                  :interval_col  (Duration/parse "PT51H4M5S")
-                                  :json_col      {:c 3}
-                                  :jsonb_col     {:d 4}
-                                  :mood_col      "sad"
-                                  :text_col      "text2"
-                                  :time_col      (LocalTime/parse "21:01:04")
-                                  :timestamp_col (LocalDateTime/parse "2024-04-23T21:01:04")})
-               result)))
+        (is
+         (= (list #:data_types{:bool_col      true
+                               :date_col      (LocalDate/parse "2024-04-22")
+                               :float_col     3.14
+                               :id            1
+                               :int_col       42
+                               :interval_col  (Duration/parse "PT26H3M4S")
+                               :json_col      {:a 1}
+                               :jsonb_col     {:b 2}
+                               :mood_col      "happy"
+                               :text_col      "text"
+                               :time_col      (LocalTime/parse "21:01:03")
+                               :timestamp_col (LocalDateTime/parse "2024-04-22T21:01:03")}
+                  #:data_types{:bool_col      false
+                               :date_col      (LocalDate/parse "2024-04-23")
+                               :float_col     3.15
+                               :id            2
+                               :int_col       43
+                               :interval_col  (Duration/parse "PT51H4M5S")
+                               :json_col      {:c 3}
+                               :jsonb_col     {:d 4}
+                               :mood_col      "sad"
+                               :text_col      "text2"
+                               :time_col      (LocalTime/parse "21:01:04")
+                               :timestamp_col (LocalDateTime/parse "2024-04-23T21:01:04")})
+            result)))
 
       (let [pipeline (collet/compile-pipeline
                       {:name  :data-types
@@ -256,8 +265,9 @@
                                                            :query      {:select [:*]
                                                                         :from   :data-types
                                                                         :where  [:= :mood_col (types/as-other mood)]}}}]}]})
-            run      (tf/run-pipeline! pipeline {:connection connection-map
-                                                 :mood       "sad"})
+            run      (tf/run-pipeline! pipeline
+                                       {:connection connection-map
+                                        :mood       "sad"})
             result   (:query run)]
         (is (= 1 (count result)))
         (is (= "sad" (-> result first :data_types/mood_col)))))
@@ -279,24 +289,24 @@
             run      (tf/run-pipeline! pipeline {:connection connection-map})
             result   (:query run)]
         (are [key expected] (= expected (-> result first key))
-          :bool_col true
-          :mood_col "happy"
-          :interval_col (Duration/parse "PT26H3M4S")
-          :json_col {:a 1}
-          :jsonb_col {:b 2}
-          :date_col (LocalDate/parse "2024-04-22")
-          :time_col (LocalTime/parse "21:01:03")
-          :timestamp_col (LocalDateTime/parse "2024-04-22T21:01:03"))
+         :bool_col      true
+         :mood_col      "happy"
+         :interval_col  (Duration/parse "PT26H3M4S")
+         :json_col      {:a 1}
+         :jsonb_col     {:b 2}
+         :date_col      (LocalDate/parse "2024-04-22")
+         :time_col      (LocalTime/parse "21:01:03")
+         :timestamp_col (LocalDateTime/parse "2024-04-22T21:01:03"))
 
         (are [key expected] (= expected (-> result second key))
-          :bool_col false
-          :mood_col "sad"
-          :interval_col (Duration/parse "PT51H4M5S")
-          :json_col {:c 3}
-          :jsonb_col {:d 4}
-          :date_col (LocalDate/parse "2024-04-23")
-          :time_col (LocalTime/parse "21:01:04")
-          :timestamp_col (LocalDateTime/parse "2024-04-23T21:01:04"))))
+         :bool_col      false
+         :mood_col      "sad"
+         :interval_col  (Duration/parse "PT51H4M5S")
+         :json_col      {:c 3}
+         :jsonb_col     {:d 4}
+         :date_col      (LocalDate/parse "2024-04-23")
+         :time_col      (LocalTime/parse "21:01:04")
+         :timestamp_col (LocalDateTime/parse "2024-04-23T21:01:04"))))
 
     ;; add 20 more records to the table
     (with-open [conn (jdbc/get-connection connection-map)]
@@ -321,10 +331,12 @@
                                                                            :from   :data-types}}}]}]})
             run      (tf/run-pipeline! pipeline {:connection connection-map})
             result   (:query run)
-            columns  (-> result meta :arrow-columns)]
-        (is (= 3 (count result)))
-        (is (utils/ds-seq? result))
-        (is (= [10 10 2] (map ds/row-count result)))
+            datasets (collet/arrow->dataset result)
+            columns  (-> datasets meta :arrow-columns)]
+        (is (collet/arrow-task-result? result))
+        (is (= 3 (count datasets)))
+        (is (utils/ds-seq? datasets))
+        (is (= [10 10 2] (map ds/row-count datasets)))
         (is (= {:id            1
                 :bool_col      true
                 :mood_col      "happy"
@@ -332,7 +344,7 @@
                 :date_col      (LocalDate/parse "2024-04-22")
                 :time_col      (LocalTime/parse "21:01:03")
                 :timestamp_col (LocalDateTime/parse "2024-04-22T21:01:03")}
-               (-> (first result)
+               (-> (first datasets)
                    (ds/row-at 0)
                    (collet.arrow/prep-record columns))))))
 
@@ -432,8 +444,8 @@
                                                                        :from     :employees
                                                                        :order-by [:id]}}
                                               :return    [[:$/cat :employees/user_name]]}]}]})
-            _        (with-open [conn (jdbc/get-connection connection-map)]
-                       (containers/populate-employees! conn))
+            _ (with-open [conn (jdbc/get-connection connection-map)]
+                (containers/populate-employees! conn))
             run      (tf/run-pipeline! pipeline {:connection connection-map})
             result   (:query run)]
         (is (= 5 (count result)))
@@ -519,9 +531,9 @@
                                                                            :order-by [:u.username :p.product_name]}
                                                               :options    {:dialect :mysql
                                                                            :quoted  false}}}]}]})
-            _        (with-open [conn (jdbc/get-connection connection-map)]
-                       (create-tables conn)
-                       (populate-orders-data conn))
+            _ (with-open [conn (jdbc/get-connection connection-map)]
+                (create-tables conn)
+                (populate-orders-data conn))
             run      (tf/run-pipeline! pipeline {:connection connection-map})
             result   (:query run)]
         (is (instance? LazySeq result))

--- a/collet-action-jslt/test/collet/actions/jslt_test.clj
+++ b/collet-action-jslt/test/collet/actions/jslt_test.clj
@@ -1,43 +1,43 @@
 (ns collet.actions.jslt-test
   (:require
    [clojure.test :refer :all]
-   [collet.core :as collet]
    [collet.action :as action]
    [collet.actions.jslt :as sut]
+   [collet.core :as collet]
    [collet.test-fixtures :as tf]))
 
 
 (deftest jslt-action-test
   (are [input template expected]
-    (let [action-spec {:type   ::sut/apply
-                       :params {:template template}}
-          {:keys [params]} (action/prep action-spec)
-          action-fn   (action/action-fn action-spec)
-          result      (action-fn (merge params {:input input :as :string}))]
-      (= expected result))
+   (let [action-spec      {:type   ::sut/apply
+                           :params {:template template}}
+         {:keys [params]} (action/prep action-spec)
+         action-fn        (action/action-fn action-spec)
+         result           (action-fn (merge params {:input input :as :string}))]
+     (= expected result))
 
-    ;; Test cases
-    "{\"key\": \"value\"}" "{\"newKey\": .key}" "{\"newKey\":\"value\"}"
-    "{\"key\": \"value\"}" "{\"someKey\": \"value\", \"newKey\": .missingKey}" "{\"someKey\":\"value\"}"
-    "{\"key\": {\"nestedKey\": \"nestedValue\"}}" "{\"newKey\": .key.nestedKey}" "{\"newKey\":\"nestedValue\"}"
-    "{\"key\": [1, 2, 3]}" "{\"newKey\": .key[1]}" "{\"newKey\":2}")
+   ;; Test cases
+   "{\"key\": \"value\"}" "{\"newKey\": .key}"    "{\"newKey\":\"value\"}"
+   "{\"key\": \"value\"}" "{\"someKey\": \"value\", \"newKey\": .missingKey}" "{\"someKey\":\"value\"}"
+   "{\"key\": {\"nestedKey\": \"nestedValue\"}}" "{\"newKey\": .key.nestedKey}" "{\"newKey\":\"nestedValue\"}"
+   "{\"key\": [1, 2, 3]}" "{\"newKey\": .key[1]}" "{\"newKey\":2}")
 
   (are [input template expected]
-    (let [action-spec {:type   ::sut/apply
-                       :params {:template template}}
-          {:keys [params]} (action/prep action-spec)
-          action-fn   (action/action-fn action-spec)
-          result      (action-fn (merge params {:input input}))]
-      (= expected result))
+   (let [action-spec      {:type   ::sut/apply
+                           :params {:template template}}
+         {:keys [params]} (action/prep action-spec)
+         action-fn        (action/action-fn action-spec)
+         result           (action-fn (merge params {:input input}))]
+     (= expected result))
 
-    ;; Test case for returning value as Clojure data
-    "{\"key\": \"value\"}" "{\"newKey\": .key}" {:newKey "value"}
-    "{\"key\": {\"nestedKey\": \"value\"}}" "{\"newKey\": .key.nestedKey}" {:newKey "value"}
-    "{\"key\": {\"nestedKey\": \"value\"}}" "{\"foo\": {\"bar\": .key.nestedKey}}" {:foo {:bar "value"}}
-    "{\"array\": [1, 2, 3]}" "{\"secondItem\": .array[1]}" {:secondItem 2}
-    "{\"array\": [1.3, 2.4, 3.5]}" "{\"secondItem\": .array[1]}" {:secondItem 2.4}
-    ;; input
-    "{
+   ;; Test case for returning value as Clojure data
+   "{\"key\": \"value\"}"                  "{\"newKey\": .key}"                   {:newKey "value"}
+   "{\"key\": {\"nestedKey\": \"value\"}}" "{\"newKey\": .key.nestedKey}"         {:newKey "value"}
+   "{\"key\": {\"nestedKey\": \"value\"}}" "{\"foo\": {\"bar\": .key.nestedKey}}" {:foo {:bar "value"}}
+   "{\"array\": [1, 2, 3]}"                "{\"secondItem\": .array[1]}"          {:secondItem 2}
+   "{\"array\": [1.3, 2.4, 3.5]}"          "{\"secondItem\": .array[1]}"          {:secondItem 2.4}
+   ;; input
+   "{
       \"customer_id\": 123456,
       \"customer_status\": 1,
       \"invoice_address_street\": \"McDuck Manor\",
@@ -52,7 +52,7 @@
         \"last_order\": \"2022-03-10T18:25:43.511Z\"
       }
     }"
-    ;; template
+                                           ;; template
     " def map_status(status)
         if ($status == 0)
           \"ACTIVE\"
@@ -78,18 +78,20 @@
       \"customer_class\": .attributes.customer_class,
       \"producer_team\": \"us.california.burbank.disney\"
     }"
-    ;; expected
-    {:customer_id          "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92",
-     :customer_status_code "INACTIVE",
-     :locations            [{:zip_code "1312", :city "Duckburg"}
-                            {:zip_code "1313", :city "Duckburg"}],
-     :customer_type        "C2C",
-     :customer_class       "A",
-     :producer_team        "us.california.burbank.disney"}))
+                                                                                  ;; expected
+                                                                                  {:customer_id          "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92"
+                                                                                   :customer_status_code "INACTIVE"
+                                                                                   :locations            [{:zip_code "1312" :city "Duckburg"}
+                                                                                                          {:zip_code "1313" :city "Duckburg"}]
+                                                                                   :customer_type        "C2C"
+                                                                                   :customer_class       "A"
+                                                                                   :producer_team        "us.california.burbank.disney"}))
 
 
 (deftest jslt-in-pipeline
-  (let [records   ["{
+  (let
+    [records
+     ["{
                     \"order\": {
                       \"order_id\": 1,
                       \"customer\": {
@@ -114,7 +116,7 @@
                       \"status\": \"shipped\"
                     }
                   }"
-                   "{
+      "{
                      \"order\": {
                        \"order_id\": 4,
                        \"customer\": {
@@ -133,7 +135,7 @@
                        \"status\": \"canceled\"
                        }
                      }"
-                   "{
+      "{
                      \"order\": {
                        \"order_id\": 6,
                        \"customer\": {
@@ -159,7 +161,8 @@
                        }
                      }
                      "]
-        template  "{
+     template
+     "{
                     \"order_summary\": {
                       \"order_id\": .order.order_id,
                       \"customer_name\": .order.customer.name,
@@ -169,40 +172,40 @@
                       \"order_date\":.order.order_date
                     }
                   }"
-        pipe-spec {:name  :test-jslt-pipeline
-                   :tasks [{:name       :json-transform
-                            :keep-state true
-                            :actions    [{:name      :json-records
-                                          :type      :mapper
-                                          :selectors {'records [:config :records]}
-                                          :params    {:sequence 'records}}
-                                         {:name      :transform-json
-                                          :type      :collet.actions.jslt/apply
-                                          :selectors {'json [:$mapper/item]}
-                                          :params    {:template template
-                                                      :input    'json}}]
-                            :iterator   {:next [:true? [:$mapper/has-next-item]]}}]}
-        pipeline  (collet/compile-pipeline pipe-spec)
-        run       (tf/run-pipeline! pipeline {:records records})]
+     pipe-spec {:name      :test-jslt-pipeline
+                :use-arrow false
+                :tasks     [{:name       :json-transform
+                             :keep-state true
+                             :actions    [{:name      :json-records
+                                           :type      :mapper
+                                           :selectors {'records [:config :records]}
+                                           :params    {:sequence 'records}}
+                                          {:name      :transform-json
+                                           :type      :collet.actions.jslt/apply
+                                           :selectors {'json [:$mapper/item]}
+                                           :params    {:template template
+                                                       :input    'json}}]
+                             :iterator   {:next [:true? [:$mapper/has-next-item]]}}]}
+     pipeline (collet/compile-pipeline pipe-spec)
+     run (tf/run-pipeline! pipeline {:records records})]
 
-    (is (= [{:order_summary {:customer_name "Alice"
-                             :order_date    "2023-10-01"
-                             :order_id      1
-                             :status        "Delivered"
-                             :total_cost    40.0
-                             :total_items   2}}
-            {:order_summary {:customer_name "David"
-                             :order_date    "2023-10-04"
-                             :order_id      4
-                             :status        "Cancelled"
-                             :total_cost    44.0
-                             :total_items   1}}
-            {:order_summary {:customer_name "Frank"
-                             :order_date    "2023-10-06"
-                             :order_id      6
-                             :status        "Processing"
-                             :total_cost    330.0
-                             :total_items   2}}]
-           (:json-transform run)))))
-
-
+    (is
+     (= [{:order_summary {:customer_name "Alice"
+                          :order_date    "2023-10-01"
+                          :order_id      1
+                          :status        "Delivered"
+                          :total_cost    40.0
+                          :total_items   2}}
+         {:order_summary {:customer_name "David"
+                          :order_date    "2023-10-04"
+                          :order_id      4
+                          :status        "Cancelled"
+                          :total_cost    44.0
+                          :total_items   1}}
+         {:order_summary {:customer_name "Frank"
+                          :order_date    "2023-10-06"
+                          :order_id      6
+                          :status        "Processing"
+                          :total_cost    330.0
+                          :total_items   2}}]
+        (:json-transform run)))))

--- a/collet-core/src/collet/actions/enrich.clj
+++ b/collet-core/src/collet/actions/enrich.clj
@@ -1,6 +1,7 @@
 (ns collet.actions.enrich
   (:require
    [collet.action :as action]
+   [collet.select]
    [collet.utils :as utils]))
 
 
@@ -40,7 +41,8 @@
                        (fn [acc sym path]
                          (->> (utils/replace-all path {:$enrich/item [:state mapper-key :current]})
                               (assoc acc sym)))
-                       {} selectors)
+                       {}
+                       selectors)
         execute-when' (utils/replace-all execute-when {:$enrich/item [:state mapper-key :current]})]
     ;; return a vector of three actions
     ;; slicer action
@@ -50,29 +52,31 @@
       :params    {:sequence target-sym}}
      ;; enrich (get additional data) action
      (utils/assoc-some
-       {:type      action
-        :name      action-key
-        :selectors selectors'
-        :params    params}
-       :when execute-when'
-       :fn custom-fn
-       :return return)
+      {:type      action
+       :name      action-key
+       :selectors selectors'
+       :params    params}
+      :when execute-when'
+      :fn custom-fn
+      :return return)
      ;; fold (collect results) action
      {:type      :fold
       :name      action-name
       :selectors {item-sym [:state mapper-key :current]
                   with-sym [:state action-key]}
       :params    (utils/assoc-some
-                   {:item item-sym
-                    :with with-sym}
-                   :in fold-in)}]))
+                  {:item item-sym
+                   :with with-sym}
+                  :in fold-in)}]))
 
 
-(defmethod action/prep :enrich [action-spec]
+(defmethod action/prep :enrich
+  [action-spec]
   (enrich action-spec))
 
 
-(defmethod action/expand :enrich [task action]
+(defmethod action/expand :enrich
+  [task action]
   ;; Unwraps the enrich bindings and replaces the iterator with the mapper keys
   (let [action-name (:name action)
         base-name   (name action-name)
@@ -81,10 +85,12 @@
       :always
       (assoc :state-format (or (:state-format task) :latest))
       (some? (:iterator task))
-      (update :iterator utils/replace-all
+      (update :iterator
+              utils/replace-all
               {:$enrich/item          [:state mapper-key :current]
                :$enrich/has-next-item [:state mapper-key :next]})
       (some? (:update task))
-      (update :return utils/replace-all
+      (update :return
+              utils/replace-all
               {:$enrich/item          [:state mapper-key :current]
                :$enrich/has-next-item [:state mapper-key :next]}))))

--- a/collet-core/src/collet/actions/slicer.clj
+++ b/collet-core/src/collet/actions/slicer.clj
@@ -1,29 +1,32 @@
 (ns collet.actions.slicer
   (:require
+   [collet.action :as action]
+   [collet.arrow :as collet.arrow]
+   [collet.conditions :as collet.conds]
+   [collet.select :as collet.select]
+   [collet.utils :as utils]
+   [ham-fisted.api :as hamf]
    [tech.v3.dataset :as ds]
    [tech.v3.dataset.column :as ds.col]
    [tech.v3.dataset.join :as ds.join]
+   [tech.v3.dataset.reductions :as ds.reduce]
    [tech.v3.datatype :as dtype]
    [tech.v3.datatype.bitmap :as dtype.bitmap]
-   [tech.v3.datatype.protocols :as dtype.proto]
-   [tech.v3.dataset.reductions :as ds.reduce]
-   [ham-fisted.api :as hamf]
-   [collet.action :as action]
-   [collet.conditions :as collet.conds]
-   [collet.arrow :as collet.arrow]
-   [collet.utils :as utils]
-   [collet.select :as collet.select]))
+   [tech.v3.datatype.protocols :as dtype.proto]))
 
 
 (defn concat-dataset-seq
   [dataset-seq]
-  (let [arrow-columns (-> dataset-seq meta :arrow-columns)]
-    (cond->> dataset-seq
-      (some? arrow-columns)
-      (map (fn [dataset]
-             (ds/row-map dataset #(collet.arrow/prep-record % arrow-columns))))
-      :always
-      (apply utils/parallel-concat))))
+  (let [arrow-columns (-> dataset-seq meta :arrow-columns)
+        dataset       (cond->> dataset-seq
+                        (some? arrow-columns)
+                        (map (fn [dataset]
+                               (ds/row-map dataset #(collet.arrow/prep-record % arrow-columns))))
+                        :always
+                        (apply utils/parallel-concat))]
+    (cond-> dataset
+      arrow-columns
+      (with-meta (assoc (meta dataset) :arrow-columns arrow-columns)))))
 
 
 (defn do-join
@@ -54,7 +57,9 @@
                          (= target-key :_collet_join_target)
                          (conj target-key))
         joined-ds      (ds.join/left-join
-                        [source-key target-key] left-ds right-ds)]
+                        [source-key target-key]
+                        left-ds
+                        right-ds)]
     (apply dissoc joined-ds helper-columns)))
 
 
@@ -113,23 +118,25 @@
    (into {}
          (map (fn [[k v]]
                 (let [[rf-func rf-col] (if (sequential? v) v [v k])
-                      reducer (case rf-func
-                                :values (vector-reducer rf-col)
-                                :distinct (ds.reduce/distinct
-                                           rf-col #(prep-column (assoc options :column-name rf-col) %))
-                                :count-distinct (ds.reduce/count-distinct rf-col)
-                                :first-value (ds.reduce/first-value rf-col)
-                                :row-count (ds.reduce/row-count)
-                                :mean (ds.reduce/mean rf-col)
-                                :sum (ds.reduce/sum rf-col))]
+                      reducer          (case rf-func
+                                         :values (vector-reducer rf-col)
+                                         :distinct (ds.reduce/distinct
+                                                    rf-col
+                                                    #(prep-column (assoc options :column-name rf-col) %))
+                                         :count-distinct (ds.reduce/count-distinct rf-col)
+                                         :first-value (ds.reduce/first-value rf-col)
+                                         :row-count (ds.reduce/row-count)
+                                         :mean (ds.reduce/mean rf-col)
+                                         :sum (ds.reduce/sum rf-col))]
                   [k reducer])))
          columns)))
 
 
 (defn do-fold-by
   "Fold dataset by the provided columns"
-  [dataset {:keys [by rollup rollup-except columns]
-            :or   {rollup false rollup-except false}}]
+  [dataset
+   {:keys [by rollup rollup-except columns]
+    :or   {rollup false rollup-except false}}]
   (let [rollup'           (cond
                             (true? rollup) :all
                             (vector? rollup) (set rollup)
@@ -191,8 +198,9 @@
 
 
 (defn do-group-by
-  [dataset {:keys [by join-groups group-col]
-            :or   {join-groups true group-col :_group_by_key}}]
+  [dataset
+   {:keys [by join-groups group-col]
+    :or   {join-groups true group-col :_group_by_key}}]
   (let [groups (if (utils/ds-seq? dataset)
                  (let [arrow-columns (-> dataset meta :arrow-columns)
                        groups-seq    (cond->> dataset
@@ -345,8 +353,10 @@
          :select (do-select d args)
          :map (do-map-with d args)
          d))
-     dataset apply)))
+     dataset
+     apply)))
 
 
-(defmethod action/action-fn :slicer [_]
+(defmethod action/action-fn :slicer
+  [_]
   prep-dataset)

--- a/collet-core/src/collet/actions/switch.clj
+++ b/collet-core/src/collet/actions/switch.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.walk :as walk]
    [collet.action :as action]
-   [collet.conditions :as collet.conds]))
+   [collet.conditions :as collet.conds]
+   [collet.select]))
 
 
 (defn expand-selectors [ctx selectors condition]
@@ -28,17 +29,19 @@
   (reduce
    (fn [c action-fn]
      (action-fn c))
-   ctx actions))
+   ctx
+   actions))
 
 
 (def switch-params-spec
   [:map
    [:selectors {:optional true}
     [:map-of :symbol collet.select/select-path]]
-   [:case [:vector
-           [:map
-            [:condition [:or [:= :default] collet.conds/condition?]]
-            [:actions [:vector fn?]]]]]])
+   [:case
+    [:vector
+     [:map
+      [:condition [:or [:= :default] collet.conds/condition?]]
+      [:actions [:vector fn?]]]]]])
 
 
 (defn switch-action
@@ -65,5 +68,6 @@
    case))
 
 
-(defmethod action/action-fn :switch [action-spec]
+(defmethod action/action-fn :switch
+  [action-spec]
   (partial switch-action (select-keys action-spec [:selectors :case])))

--- a/collet-core/src/collet/arrow.clj
+++ b/collet-core/src/collet/arrow.clj
@@ -1,336 +1,1482 @@
 (ns collet.arrow
   (:require
    [clojure.core.protocols :as clj-proto]
+   [malli.core :as m]
+   [malli.transform :as mt]
    [tech.v3.dataset :as ds]
    [tech.v3.dataset.utils :as ds.utils]
    [tech.v3.datatype :as dtype]
-   [tech.v3.datatype.packing :as packing]
    [tech.v3.datatype.casting :as casting]
+   [tech.v3.datatype.packing :as packing]
    [tech.v3.libs.arrow :as arrow]
-   [collet.utils :as utils])
+   [tech.v3.resource :as resource])
   (:import
-   [java.time Duration Instant LocalDate LocalDateTime LocalTime ZoneOffset]
-   [org.apache.arrow.memory RootAllocator]
-   [org.apache.arrow.vector.complex ListVector]
-   [org.apache.arrow.vector.complex.impl UnionListWriter]
-   [org.apache.arrow.vector.types TimeUnit DateUnit FloatingPointPrecision]
-   [org.apache.arrow.vector
-    BaseFixedWidthVector BaseVariableWidthVector BigIntVector BitVector DateDayVector DurationVector Float4Vector Float8Vector IntVector
-    TimeMicroVector TimeMilliVector TimeNanoVector TimeSecVector TimeStampMicroVector TimeStampMilliVector
-    TimeStampNanoVector VarCharVector VectorSchemaRoot]
-   [org.apache.arrow.vector.types.pojo
-    ArrowType$Bool ArrowType$Date ArrowType$Duration ArrowType$List ArrowType$Time ArrowType$Timestamp
-    Field FieldType ArrowType ArrowType$FloatingPoint ArrowType$Int ArrowType$Utf8 Schema]
-   [org.apache.arrow.vector.ipc ArrowFileWriter]
-   [java.io Closeable File FileOutputStream]
-   [org.apache.arrow.vector.util Text]))
+    (clojure.lang BigInt ExceptionInfo)
+    [java.io Closeable File FileOutputStream]
+    (java.lang AutoCloseable)
+    [java.math BigDecimal BigInteger RoundingMode]
+    [java.nio.channels FileChannel SeekableByteChannel]
+    [java.nio.file OpenOption Path Paths StandardOpenOption]
+    [java.time Duration Instant LocalDate LocalDateTime LocalTime ZoneOffset]
+    [java.util Date Map UUID]
+    [org.apache.arrow.memory RootAllocator]
+    [org.apache.arrow.vector
+     BigIntVector BitVector DateDayVector Decimal256Vector DecimalVector DurationVector FieldVector Float4Vector
+     Float8Vector IntVector SmallIntVector TimeMicroVector TimeMilliVector TimeNanoVector TimeSecVector
+     TimeStampMicroVector TimeStampMilliVector TimeStampNanoVector TinyIntVector UInt1Vector UInt2Vector UInt4Vector
+     UInt8Vector VarCharVector VectorSchemaRoot]
+    [org.apache.arrow.vector.complex FixedSizeListVector ListVector MapVector StructVector]
+    [org.apache.arrow.vector.complex.impl UnionListWriter]
+    [org.apache.arrow.vector.ipc ArrowFileReader ArrowFileWriter]
+    [org.apache.arrow.vector.types DateUnit FloatingPointPrecision TimeUnit]
+    [org.apache.arrow.vector.types.pojo
+     ArrowType ArrowType$Bool ArrowType$Date ArrowType$Decimal ArrowType$Duration ArrowType$FixedSizeList ArrowType$FloatingPoint
+     ArrowType$Int ArrowType$List ArrowType$Map ArrowType$Struct ArrowType$Time ArrowType$Timestamp ArrowType$Utf8 Field FieldType
+     Schema]
+    [org.apache.arrow.vector.util Text]))
+
+
+(def schema-version 1)
 
 
 (def zoned-types
   #{:instant :epoch-milliseconds :epoch-microseconds :epoch-nanoseconds})
 
 
-(casting/alias-datatype! :duration :int64)
+(def scalar-types
+  #{:boolean
+    :uint8 :int8 :uint16 :int16 :uint32 :int32 :uint64 :int64
+    :float32 :float64
+    :epoch-days :local-date :local-time :local-date-time
+    :time-nanoseconds :time-microseconds :time-milliseconds :time-seconds
+    :duration :string :uuid :text :encoded-text
+    :instant :epoch-milliseconds :epoch-microseconds :epoch-nanoseconds})
 
 
-(extend-protocol clj-proto/Datafiable
-  ArrowType$Duration
-  (datafy [this]
-    {:datatype :duration}))
+(def ^:private decimal-max-precision
+  ;; Arrow Decimal128/256 physical encodings cap precision at 38/76 digits.
+  {128 38
+   256 76})
 
 
-(def column-name
-  [:or :string :keyword])
-
-(def column-safe-name
-  :string)
-
-(def column-type
-  [:or :keyword
-   [:tuple [:= :list] :keyword]
-   [:tuple [:= :zoned] :keyword [:maybe :string]]])
-
-(def columns-spec
-  [:vector [:tuple column-name column-safe-name column-type]])
+(def ^:private map-key-descriptor
+  {:type :string :nullable? false})
 
 
-(defn ds->columns
-  "Infer a list of columns (simple representation of Arrow fields) from a dataset sample."
-  {:malli/schema [:=> [:cat [:or utils/dataset?
-                             [:sequential utils/dataset?]]]
-                  columns-spec]}
-  [dataset]
-  (->> dataset
-       (mapv (fn [[_ column]]
-               (let [{:keys [name datatype timezone]} (-> column meta)
-                     datatype    (packing/unpack-datatype datatype)
-                     column-name (ds.utils/column-safe-name name)
-                     column-type (cond
-                                   ;; not supported types
-                                   (or (= datatype :persistent-map)
-                                       (= datatype :persistent-set)
-                                       (= datatype :object))
-                                   (throw (ex-info "Complex objects aren't supported" {:column name}))
-                                   ;; list of items
-                                   (= datatype :persistent-vector)
-                                   (let [item-type (->> column
-                                                        (mapcat #(map dtype/elemwise-datatype %))
-                                                        (set))
-                                         item-type (if (or (empty? item-type) (> (count item-type) 1))
-                                                     :string
-                                                     (-> (first item-type)
-                                                         (packing/unpack-datatype)))]
-                                     (when (or (= item-type :persistent-map)
-                                               (= item-type :persistent-set)
-                                               (= item-type :object))
-                                       (throw (ex-info "Complex objects aren't supported" {:column name})))
-                                     [:list item-type])
-                                   ;; temporal types with timezone
-                                   (contains? zoned-types datatype)
-                                   [:zoned datatype timezone]
-                                   ;; other types
-                                   :otherwise
-                                   datatype)]
-                 [name column-name column-type])))))
-
-
-(defn get-columns
-  "Get a list of columns from a dataset. If nil returned it means that dataset cannot be written as Arrow file."
-  [data]
-  (if (empty? data)
-    nil
-    (try
-      (let [ds-sample (if (ds/dataset? data)
-                        (ds/sample data (min 200 (ds/row-count data)))
-                        (repeatedly
-                         (min (count data) 200)
-                         #(rand-nth data)))]
-        (-> (utils/make-dataset ds-sample {})
-            (ds->columns)
-            (not-empty)))
-      (catch Exception _ex
-        nil))))
-
-
-(defn find-column
-  [columns column-name]
-  (some
-   (fn [[key name _ :as column]]
-     (when (or (= key column-name) (= name column-name))
-       column))
-   columns))
-
-
-(defn create-zoned-field
-  [column-name column-type ^String timezone]
-  (let [timezone   (or timezone "UTC")
-        field-type ^ArrowType
-                   (case column-type
-                     :instant (ArrowType$Timestamp. TimeUnit/MICROSECOND timezone)
-                     :epoch-milliseconds (ArrowType$Timestamp. TimeUnit/MILLISECOND timezone)
-                     :epoch-microseconds (ArrowType$Timestamp. TimeUnit/MICROSECOND timezone)
-                     :epoch-nanoseconds (ArrowType$Timestamp. TimeUnit/NANOSECOND timezone))]
-    (Field. (name column-name) (FieldType/nullable field-type) nil)))
-
-
-(defn create-field
-  [column-name column-type]
-  (let [field-type ^ArrowType
-                   (case column-type
-                     :boolean (ArrowType$Bool.)
-                     :uint8 (ArrowType$Int. 8 false)
-                     :int8 (ArrowType$Int. 8 true)
-                     :uint16 (ArrowType$Int. 16 false)
-                     :int16 (ArrowType$Int. 16 true)
-                     :uint32 (ArrowType$Int. 32 false)
-                     :int32 (ArrowType$Int. 32 true)
-                     :uint64 (ArrowType$Int. 64 false)
-                     :int64 (ArrowType$Int. 64 true)
-                     :float32 (ArrowType$FloatingPoint. FloatingPointPrecision/SINGLE)
-                     :float64 (ArrowType$FloatingPoint. FloatingPointPrecision/DOUBLE)
-                     :epoch-days (ArrowType$Date. DateUnit/DAY)
-                     :local-date (ArrowType$Date. DateUnit/DAY)
-                     :local-time (ArrowType$Time. TimeUnit/MICROSECOND (int 64))
-                     :local-date-time (ArrowType$Timestamp. TimeUnit/MICROSECOND nil)
-                     :time-nanoseconds (ArrowType$Time. TimeUnit/NANOSECOND (int 64))
-                     :time-microseconds (ArrowType$Time. TimeUnit/MICROSECOND (int 64))
-                     :time-milliseconds (ArrowType$Time. TimeUnit/MILLISECOND (int 32))
-                     :time-seconds (ArrowType$Time. TimeUnit/SECOND (int 32))
-                     :duration (ArrowType$Duration. TimeUnit/MICROSECOND)
-                     :string (ArrowType$Utf8.)
-                     :uuid (ArrowType$Utf8.)
-                     :text (ArrowType$Utf8.)
-                     :encoded-text (ArrowType$Utf8.))]
-    (Field. (name column-name) (FieldType/nullable field-type) nil)))
-
-
-(defn create-schema
-  [columns]
-  "Create an Arrow schema based on the column definitions."
-  (Schema. ^Iterable
-           (->> columns
-                (map (fn [[_column-key column-name column-type]]
-                       (cond
-                         ;; list of items
-                         (and (vector? column-type) (= :list (first column-type)))
-                         (Field. column-name
-                                 (FieldType/nullable ArrowType$List/INSTANCE)
-                                 [(create-field (str column-name "_item") (second column-type))])
-                         ;; temporal types with timezone
-                         (and (vector? column-type) (= :zoned (first column-type)))
-                         (apply create-zoned-field column-name (rest column-type))
-                         ;; other types
-                         :otherwise
-                         (create-field column-name column-type)))))))
-
-
-(defn local-time->millis ^Integer
-  [^LocalTime t]
-  (let [seconds (.toSecondOfDay t)
-        nanos   (.getNano t)
-        millis  (+ (* seconds 1000) (quot nanos 1000000))]
-    (int millis)))
-
-
-(defn local-time->micros ^long
-  [^LocalTime t]
-  (let [seconds (.toSecondOfDay t)
-        nanos   (.getNano t)
-        micros  (+ (* seconds 1000000) (long (/ nanos 1000)))]
-    micros))
-
-
-(defn duration->micros ^long
-  [^Duration d]
-  (let [seconds (.getSeconds d)
-        nanos   (.getNano d)]
-    (+ (* seconds 1000000) (quot nanos 1000))))
-
-
-(defn instant->micros ^long
-  [^Instant inst]
-  (let [seconds (.getEpochSecond inst)
-        nanos   (.getNano inst)]
-    (+ (* seconds 1000000) (quot nanos 1000))))
-
-
-(defn date-time->micros ^long
-  [^LocalDateTime date-time]
-  (let [seconds (.toEpochSecond date-time ZoneOffset/UTC)
-        nanos   (.getNano date-time)]
-    (+ (* seconds 1000000) (quot nanos 1000))))
-
-
-(defn instant->nanos ^long
-  [^Instant inst]
-  (let [seconds (.getEpochSecond inst)
-        nanos   (.getNano inst)]
-    (+ (* seconds 1000000000) nanos)))
+(def ^:private map-value-descriptor
+  {:type :string :nullable? true})
 
 
 (def varchar-types
   #{:string :uuid :text :encoded-text})
 
 
-(defn write-list-item
-  [^UnionListWriter list-writer column-type item]
+(casting/alias-datatype! :duration :int64)
+
+
+(extend-protocol clj-proto/Datafiable
+ ArrowType$Duration
+ (datafy [_]
+   {:datatype :duration}))
+
+
+(defn- class-name
+  [value]
+  (when (some? value)
+    (.getName (class value))))
+
+
+(defn- arrow-error!
+  [type message data]
+  (throw
+   (ex-info message
+            (assoc data :collet.error/type type))))
+
+
+(defn- schema-error!
+  [reason message]
+  (arrow-error! :collet.error/arrow-invalid-schema
+                message
+                {:reason reason}))
+
+
+(defn- value-error!
+  [path descriptor reason value]
+  (arrow-error!
+   :collet.error/arrow-invalid-value
+   (str "Invalid Arrow value at " (pr-str path) ".")
+   {:path         path
+    :expected     (case (:type descriptor)
+                    :decimal (str "decimal"
+                                  (:bit-width descriptor)
+                                  "("
+                                  (:precision descriptor)
+                                  ","
+                                  (:scale descriptor)
+                                  ")")
+                    :fixed-size-list (str "fixed-size-list[" (:size descriptor) "]")
+                    (name (:type descriptor)))
+    :reason       reason
+    :actual-class (or (class-name value) "nil")}))
+
+
+(defn- legacy-date-error!
+  [path value]
+  (arrow-error!
+   :collet.error/arrow-legacy-date
+   (str "Legacy java.util.Date is not supported at " (pr-str path) ".")
+   {:path         path
+    :reason       :legacy-java-util-date
+    :actual-class (class-name value)
+    :remediation  "Use Instant, LocalDate, LocalDateTime, or LocalTime."}))
+
+
+(defn- schema-required!
+  [path reason value]
+  (arrow-error!
+   :collet.error/arrow-schema-required
+   (str "An explicit :arrow-columns schema is required at " (pr-str path) ".")
+   {:path         path
+    :reason       reason
+    :actual-class (or (class-name value) "nil")}))
+
+
+(def ^:private schema-error-messages
+  {:invalid-descriptor           "Arrow descriptor must be a keyword or map."
+   :duplicate-field-name         "Arrow field names must be unique."
+   :duplicate-field-key          "Arrow field keys must be unique."
+   :invalid-map-key              "Arrow Map keys must be non-null UTF-8 strings."
+   :invalid-map-value            "Arrow Map values must be nullable UTF-8 strings."
+   :invalid-struct               "Arrow Struct requires an ordered :fields vector."
+   :missing-list-element         "Arrow List requires :element."
+   :invalid-fixed-size           "Arrow fixed-size list requires a positive :size."
+   :invalid-fixed-size-element   "Arrow fixed-size lists currently require Float32 elements."
+   :invalid-decimal-width        "Arrow decimal :bit-width must be 128 or 256."
+   :invalid-decimal-scale        "Arrow decimal scale must be between zero and its precision."
+   :invalid-decimal-logical-type "Arrow decimal logical type must be :big-integer when present."
+   :invalid-big-integer-scale    "Logical BigInteger decimals require scale zero."
+   :invalid-timezone             "Arrow timezone must be a string."
+   :invalid-field-key            "Arrow field :key must be a keyword or string."
+   :invalid-field-name           "Arrow field :name must be a string."
+   :invalid-schema               "Arrow schema must be a map or legacy column vector."
+   :invalid-fields               "Arrow schema requires an ordered :fields vector."
+   :invalid-legacy-column        "Arrow columns must use a known legacy type or descriptor map."})
+
+
+(def ^:private legacy-column-shape-message
+  "Legacy Arrow columns must be [key physical-name type] triplets.")
+
+
+(defn- schema-error-message
+  [reason value]
+  (case reason
+    :invalid-decimal-precision
+    (str "Arrow decimal precision must be between 1 and "
+         (get decimal-max-precision (:bit-width value))
+         ".")
+
+    :unsupported-type
+    (str "Unsupported Arrow type " (pr-str (:type value)) ".")
+
+    :unsupported-schema-version
+    (str "Unsupported Arrow schema version " (pr-str (:version value)) ".")
+
+    (get schema-error-messages reason)))
+
+
+(defn- schema-rule
+  ([reason predicate]
+   (schema-rule reason nil nil predicate))
+  ([reason path predicate]
+   (schema-rule reason path nil predicate))
+  ([reason path error-message predicate]
+   (let [message    (or error-message
+                        (get schema-error-messages reason)
+                        #(schema-error-message reason %))
+         properties (cond-> {::reason  reason
+                             ::message message}
+                      path (assoc :error/path path)
+                      (string? message) (assoc :error/message message)
+                      (fn? message) (assoc :error/fn
+                                      (fn [{:keys [value]} _]
+                                        (message value))))]
+     [:fn properties predicate])))
+
+
+(defn- field-values-unique?
+  [field-key fields]
+  (or (not (vector? fields))
+      (= (count fields) (count (set (map field-key fields))))))
+
+
+(defn- legacy-type?
+  [column-type]
+  (or (keyword? column-type)
+      (and (vector? column-type) (= :list (first column-type)))
+      (and (vector? column-type) (= :zoned (first column-type)))
+      (map? column-type)))
+
+
+(defn- legacy-column-shape?
+  [column]
+  (and (vector? column) (= 3 (count column))))
+
+
+(defn- legacy-column?
+  [column]
+  (and (legacy-column-shape? column)
+       (legacy-type? (nth column 2))))
+
+
+(defn- legacy-columns-shape?
+  [columns]
+  (and (vector? columns)
+       (every? legacy-column-shape? columns)))
+
+
+(defn- legacy-columns?
+  [columns]
+  (and (legacy-columns-shape? columns)
+       (every? legacy-column? columns)))
+
+
+(declare legacy-column-error)
+
+
+(defn- valid-legacy-columns?
+  [columns]
+  (or (not (vector? columns))
+      (nil? (legacy-column-error columns))))
+
+
+(def ^:private legacy-columns-schema-rule
+  [:fn
+   {::reason    #(some-> (legacy-column-error %)
+                         :reason)
+    ::message   #(some-> (legacy-column-error %)
+                         :message)
+    :error/path [:fields]}
+   valid-legacy-columns?])
+
+
+(defn- legacy-type->descriptor
+  [column-type]
   (cond
-    (= column-type :boolean) (.writeBit list-writer (if item 1 0))
-    (= column-type :uint8) (.writeUInt1 list-writer (byte item))
-    (= column-type :int8) (.writeTinyInt list-writer (byte item))
-    (= column-type :uint16) (.writeUInt2 list-writer (short item))
-    (= column-type :int16) (.writeSmallInt list-writer (short item))
-    (= column-type :uint32) (.writeUInt4 list-writer (int item))
-    (= column-type :int32) (.writeInt list-writer (int item))
-    (= column-type :uint64) (.writeUInt8 list-writer (long item))
-    (= column-type :int64) (.writeBigInt list-writer (long item))
-    (= column-type :float32) (.writeFloat4 list-writer (float item))
-    (= column-type :float64) (.writeFloat8 list-writer (double item))
-    (= column-type :epoch-days) (.writeDateDay list-writer (.toEpochDay ^LocalDate item))
-    (= column-type :local-date) (.writeDateDay list-writer (.toEpochDay ^LocalDate item))
-    (= column-type :local-time) (.writeTimeMicro list-writer (local-time->micros item))
-    (= column-type :local-date-time) (.writeTimeMicro list-writer (date-time->micros item))
-    (= column-type :time-nanoseconds) (.writeTimeNano list-writer (.toNanoOfDay ^LocalTime item))
-    (= column-type :time-microseconds) (.writeTimeMicro list-writer (local-time->micros item))
-    (= column-type :time-milliseconds) (.writeTimeMilli list-writer (local-time->millis item))
-    (= column-type :time-seconds) (.writeTimeSec list-writer (.toSecondOfDay ^LocalTime item))
-    (= column-type :duration) (.writeDuration list-writer (duration->micros item))
-    (contains? varchar-types column-type) (.writeVarChar list-writer (str item))
-    (= column-type :instant) (.writeTimeStampMicro list-writer (instant->micros item))
-    (= column-type :epoch-milliseconds) (.writeTimeStampMilli list-writer (.toEpochMilli ^Instant item))
-    (= column-type :epoch-microseconds) (.writeTimeStampMicro list-writer (instant->micros item))
-    (= column-type :epoch-nanoseconds) (.writeTimeStampNano list-writer (instant->nanos item))
-    :otherwise (throw (ex-info "Unsupported column type" {:column-type column-type}))))
+    (keyword? column-type)
+    {:type column-type}
+
+    (and (vector? column-type) (= :list (first column-type)))
+    {:type    :list
+     :element {:type (second column-type)}}
+
+    (and (vector? column-type) (= :zoned (first column-type)))
+    {:type     (second column-type)
+     :timezone (nth column-type 2 nil)}
+
+    :else
+    column-type))
+
+
+(defn- legacy-column->field-input
+  [[key name column-type]]
+  (merge (legacy-type->descriptor column-type)
+         {:key key :name name}))
+
+
+(defn- decode-descriptor-input
+  [descriptor]
+  (if (keyword? descriptor)
+    {:type descriptor}
+    descriptor))
+
+
+(defn- decode-schema-input
+  [columns]
+  (if (legacy-columns? columns)
+    {:version schema-version
+     :fields  (mapv legacy-column->field-input columns)}
+    columns))
+
+
+(defn- decode-zoned-descriptor
+  [descriptor]
+  (assoc descriptor :timezone (or (:timezone descriptor) "UTC")))
+
+
+(defn- decode-map-descriptor
+  [descriptor]
+  (assoc descriptor
+    :key-type (or (:key-type descriptor) map-key-descriptor)
+    :value-type (or (:value-type descriptor) map-value-descriptor)))
+
+
+(defn- decimal-bit-width?
+  [{:keys [bit-width]}]
+  (contains? decimal-max-precision bit-width))
+
+
+(defn- decimal-precision?
+  [{:keys [bit-width precision]}]
+  (if-let [max-precision (get decimal-max-precision bit-width)]
+    (and (integer? precision)
+         (pos? precision)
+         (<= precision max-precision))
+    true))
+
+
+(defn- decimal-scale?
+  [{:keys [bit-width precision scale] :as descriptor}]
+  (if (and (decimal-bit-width? descriptor)
+           (decimal-precision? descriptor))
+    (and (integer? scale)
+         (<= 0 scale precision))
+    true))
+
+
+(defn- decimal-logical-type?
+  [{:keys [logical-type] :as descriptor}]
+  (if (and (decimal-bit-width? descriptor)
+           (decimal-precision? descriptor)
+           (decimal-scale? descriptor))
+    (or (nil? logical-type)
+        (= logical-type :big-integer))
+    true))
+
+
+(defn- decimal-big-integer-scale?
+  [{:keys [logical-type scale] :as descriptor}]
+  (if (and (decimal-bit-width? descriptor)
+           (decimal-precision? descriptor)
+           (decimal-scale? descriptor)
+           (decimal-logical-type? descriptor))
+    (or (not= logical-type :big-integer)
+        (= scale 0))
+    true))
+
+
+(def ^:private nullable-entry
+  [:nullable? {:optional true}
+   [:boolean
+    {:default      true
+     :decode/arrow boolean}]])
+
+
+(defn- descriptor-map
+  ([type entries]
+   (descriptor-map type nil entries))
+  ([type properties entries]
+   (into (cond-> [:map]
+           properties (conj properties))
+         (concat [[:type [:= type]]
+                  nullable-entry]
+                 entries))))
+
+
+(defn- zoned-descriptor-schema
+  [type]
+  [:and
+   (descriptor-map type
+                   {:decode/arrow {:enter decode-zoned-descriptor}}
+                   [[:timezone {:optional true} :any]])
+   (schema-rule :invalid-timezone
+                [:timezone]
+                #(string? (:timezone %)))])
+
+
+(def ^:private scalar-descriptor-schema
+  [:and
+   [:map
+    [:type {:optional true} :any]
+    nullable-entry]
+   (schema-rule :unsupported-type
+                [:type]
+                #(contains? scalar-types (:type %)))])
+
+
+(def ^:private struct-descriptor-schema
+  [:and
+   (descriptor-map :struct
+                   [[:fields {:optional true}
+                     [:vector [:ref ::field]]]])
+   (schema-rule :invalid-struct
+                [:fields]
+                #(vector? (:fields %)))
+   (schema-rule :duplicate-field-name
+                [:fields]
+                #(field-values-unique? :name (:fields %)))
+   (schema-rule :duplicate-field-key
+                [:fields]
+                #(field-values-unique? :key (:fields %)))])
+
+
+(def ^:private map-descriptor-schema
+  [:and
+   (descriptor-map :map
+                   {:decode/arrow {:enter decode-map-descriptor}}
+                   [[:key-type {:optional true} [:ref ::descriptor]]
+                    [:value-type {:optional true} [:ref ::descriptor]]])
+   (schema-rule :invalid-map-key
+                [:key-type]
+                #(= map-key-descriptor
+                    (select-keys (:key-type %) [:type :nullable?])))
+   (schema-rule :invalid-map-value
+                [:value-type]
+                #(= map-value-descriptor
+                    (select-keys (:value-type %) [:type :nullable?])))])
+
+
+(def ^:private list-descriptor-schema
+  [:and
+   (descriptor-map :list
+                   [[:element {:optional true} [:ref ::descriptor]]])
+   (schema-rule :missing-list-element
+                [:element]
+                #(contains? % :element))])
+
+
+(def ^:private fixed-size-list-descriptor-schema
+  [:and
+   (descriptor-map :fixed-size-list
+                   [[:size {:optional true} :any]
+                    [:element {:optional true} [:ref ::descriptor]]])
+   (schema-rule :invalid-fixed-size
+                [:size]
+                #(and (integer? (:size %))
+                      (pos? (:size %))))
+   (schema-rule :invalid-fixed-size
+                [:size]
+                (str "Arrow fixed-size list :size must not exceed "
+                     Integer/MAX_VALUE
+                     ".")
+                #(or (not (and (integer? (:size %))
+                               (pos? (:size %))))
+                     (<= (:size %) Integer/MAX_VALUE)))
+   (schema-rule :invalid-fixed-size-element
+                [:element]
+                #(= :float32 (get-in % [:element :type])))])
+
+
+(def ^:private decimal-descriptor-schema
+  [:and
+   (descriptor-map :decimal
+                   [[:bit-width {:optional true} :any]
+                    [:precision {:optional true} :any]
+                    [:scale {:optional true} :any]
+                    [:logical-type {:optional true} :any]])
+   (schema-rule :invalid-decimal-width [:bit-width] decimal-bit-width?)
+   (schema-rule :invalid-decimal-precision [:precision] decimal-precision?)
+   (schema-rule :invalid-decimal-scale [:scale] decimal-scale?)
+   (schema-rule :invalid-decimal-logical-type [:logical-type] decimal-logical-type?)
+   (schema-rule :invalid-big-integer-scale [:scale] decimal-big-integer-scale?)])
+
+
+(def ^:private arrow-schema-registry
+  {::descriptor-input
+   [:and
+    (schema-rule :invalid-descriptor #(or (keyword? %) (map? %)))
+    [:or
+     [:keyword {:decode/arrow decode-descriptor-input}]
+     :map]]
+
+   ::descriptor
+   [:and
+    [:ref ::descriptor-input]
+    (into [:multi {:dispatch :type}]
+          [[:struct struct-descriptor-schema]
+           [:map map-descriptor-schema]
+           [:list list-descriptor-schema]
+           [:fixed-size-list fixed-size-list-descriptor-schema]
+           [:decimal decimal-descriptor-schema]
+           [:instant (zoned-descriptor-schema :instant)]
+           [:epoch-milliseconds (zoned-descriptor-schema :epoch-milliseconds)]
+           [:epoch-microseconds (zoned-descriptor-schema :epoch-microseconds)]
+           [:epoch-nanoseconds (zoned-descriptor-schema :epoch-nanoseconds)]
+           [::m/default scalar-descriptor-schema]])]
+
+   ::field
+   [:and
+    [:ref ::descriptor]
+    [:map
+     [:key {:optional true} :any]
+     [:name {:optional true} :any]]
+    (schema-rule :invalid-field-key
+                 [:key]
+                 #(or (keyword? (:key %)) (string? (:key %))))
+    (schema-rule :invalid-field-name
+                 [:name]
+                 #(string? (:name %)))]
+
+   ::schema-input
+   [:and
+    (schema-rule :invalid-schema #(or (map? %) (vector? %)))
+    legacy-columns-schema-rule
+    [:or
+     [:vector {:decode/arrow decode-schema-input} :any]
+     :map]]
+
+   ::schema
+   [:and
+    [:ref ::schema-input]
+    (schema-rule :unsupported-schema-version
+                 [:version]
+                 #(= schema-version (:version %)))
+    (schema-rule :invalid-fields
+                 [:fields]
+                 #(vector? (:fields %)))
+    [:map
+     [:version {:optional true}
+      [:any
+       {:default      schema-version
+        :decode/arrow #(or % schema-version)}]]
+     [:fields {:optional true}
+      [:vector [:ref ::field]]]]
+    (schema-rule :duplicate-field-name
+                 [:fields]
+                 #(field-values-unique? :name (:fields %)))
+    (schema-rule :duplicate-field-key
+                 [:fields]
+                 #(field-values-unique? :key (:fields %)))]})
+
+
+(defn- schema-reference
+  [reference]
+  [:schema {:registry arrow-schema-registry}
+   [:ref reference]])
+
+
+(def ^:private descriptor-schema
+  (m/schema (schema-reference ::descriptor)))
+
+
+(def ^:private field-schema
+  (m/schema (schema-reference ::field)))
+
+
+(def ^:private arrow-schema
+  (m/schema (schema-reference ::schema)))
+
+
+(def ^:private arrow-transformer
+  (mt/transformer {:name :arrow}
+                  (mt/default-value-transformer {::mt/add-optional-keys true})))
+
+
+(def ^:private decode-descriptor
+  (m/decoder descriptor-schema arrow-transformer))
+
+
+(def ^:private decode-field
+  (m/decoder field-schema arrow-transformer))
+
+
+(def ^:private decode-schema
+  (m/decoder arrow-schema arrow-transformer))
+
+
+(def ^:private explain-descriptor
+  (m/explainer descriptor-schema))
+
+
+(def ^:private explain-field
+  (m/explainer field-schema))
+
+
+(def ^:private explain-schema
+  (m/explainer arrow-schema))
+
+
+(defn- resolve-validation-property
+  [property value]
+  (if (fn? property)
+    (property value)
+    property))
+
+
+(defn- explanation-schema-error
+  [explanation]
+  (some (fn [error]
+          (let [properties (m/properties (:schema error))
+                reason     (resolve-validation-property (::reason properties) (:value error))]
+            (when reason
+              {:reason  reason
+               :message (resolve-validation-property (::message properties) (:value error))})))
+        (:errors explanation)))
+
+
+(defn- legacy-column-error
+  [columns]
+  (some (fn [column]
+          (cond
+            (not (legacy-column-shape? column))
+            {:reason  :invalid-legacy-column
+             :message legacy-column-shape-message}
+
+            (not (legacy-type? (nth column 2)))
+            {:reason  :invalid-legacy-column
+             :message (get schema-error-messages :invalid-legacy-column)}
+
+            :else
+            (explanation-schema-error
+             (explain-field
+              (decode-field (legacy-column->field-input column))))))
+        columns))
+
+
+(defn- schema-error-from-explanation!
+  [explanation]
+  (if-let [{:keys [reason message]} (explanation-schema-error explanation)]
+    (schema-error! reason message)
+    (schema-error! :invalid-schema
+                   (schema-error-message :invalid-schema nil))))
+
+
+(defn- normalize-with
+  [decoder explainer value]
+  (let [value (decoder value)]
+    (if-let [explanation (explainer value)]
+      (schema-error-from-explanation! explanation)
+      value)))
+
+
+(defn normalize-descriptor
+  "Normalize a scalar or nested descriptor into the versioned Arrow schema form."
+  [descriptor]
+  (normalize-with decode-descriptor explain-descriptor descriptor))
+
+
+(defn normalize-field
+  "Normalize a named field descriptor. Struct fields use the same shape."
+  [field]
+  (normalize-with decode-field explain-field field))
+
+
+(defn normalize-schema
+  "Accept legacy column triplets or a versioned schema map and return canonical EDN."
+  [columns]
+  (select-keys (normalize-with decode-schema explain-schema columns)
+               [:version :fields]))
+
+
+(defn- legacy-column->field
+  [column]
+  (-> (normalize-schema [column])
+      :fields
+      first))
+
+
+(defn- schema-fields
+  [columns]
+  (:fields (normalize-schema columns)))
+
+
+(defn find-column
+  [columns column-name]
+  (let [column-name-string (str column-name)]
+    (some
+     (fn [field]
+       (when (or (= (:key field) column-name)
+                 (= (:name field) column-name-string)
+                 (= (str (:key field)) column-name-string)
+                 (= (keyword (:name field)) column-name))
+         field))
+     (schema-fields columns))))
+
+
+(defn ds->columns
+  "Infer legacy column triplets from a tech.ml.dataset sample."
+  [dataset]
+  (->> dataset
+       (mapv
+        (fn [[_ column]]
+          (let [{:keys [name datatype timezone]} (-> column meta)
+                datatype    (packing/unpack-datatype datatype)
+                column-name (ds.utils/column-safe-name name)
+                column-type (cond
+                              (or (= datatype :persistent-map)
+                                  (= datatype :persistent-set)
+                                  (= datatype :object))
+                              (throw (ex-info "Complex objects require an explicit Arrow schema."
+                                              {:column name}))
+
+                              (= datatype :persistent-vector)
+                              (let [item-types (->> column
+                                                    (mapcat #(map dtype/elemwise-datatype %))
+                                                    set)
+                                    item-type  (if (or (empty? item-types)
+                                                       (> (count item-types) 1))
+                                                 :string
+                                                 (packing/unpack-datatype (first item-types)))]
+                                (when (or (= item-type :persistent-map)
+                                          (= item-type :persistent-set)
+                                          (= item-type :object))
+                                  (throw (ex-info "Complex objects require an explicit Arrow schema."
+                                                  {:column name})))
+                                [:list item-type])
+
+                              (contains? zoned-types datatype)
+                              [:zoned datatype timezone]
+
+                              :otherwise
+                              datatype)]
+            [name column-name column-type])))))
+
+
+(defn- sample-records
+  [data]
+  (cond
+    (ds/dataset? data)
+    (mapv #(ds/row-at data %)
+          (range (min 200 (ds/row-count data))))
+
+    :else
+    (vec (take 200 (or (seq data) ())))))
+
+
+(defn- scalar-inference
+  [path value]
+  (cond
+    (instance? Date value)
+    (legacy-date-error! path value)
+
+    (instance? Boolean value)
+    {:type :boolean}
+
+    (instance? Byte value)
+    {:type :int8}
+
+    (instance? Short value)
+    {:type :int16}
+
+    (instance? Integer value)
+    {:type :int32}
+
+    (instance? Long value)
+    {:type :int64}
+
+    (instance? Float value)
+    {:type :float32}
+
+    (instance? Double value)
+    {:type :float64}
+
+    (or (instance? BigInteger value)
+        (instance? BigInt value)
+        (instance? BigDecimal value))
+    (schema-required! path :decimal-or-big-integer value)
+
+    (string? value)
+    {:type :string}
+
+    (instance? UUID value)
+    {:type :uuid}
+
+    (instance? LocalDate value)
+    {:type :local-date}
+
+    (instance? LocalTime value)
+    {:type :local-time}
+
+    (instance? LocalDateTime value)
+    {:type :local-date-time}
+
+    (instance? Instant value)
+    {:type :instant :timezone "UTC"}
+
+    (instance? Duration value)
+    {:type :duration}
+
+    (map? value)
+    (schema-required! path :struct-or-map value)
+
+    (and (sequential? value) (not (string? value)))
+    (let [items       (take 200 value)
+          descriptors (mapv #(scalar-inference (conj path :item) %) (remove nil? items))]
+      (when (empty? descriptors)
+        (schema-required! path :empty-or-all-null-list value))
+      (when (or (not-every? #(contains? scalar-types (:type %)) descriptors)
+                (> (count (distinct descriptors)) 1))
+        (schema-required! path :mixed-or-nested-list value))
+      {:type    :list
+       :element (assoc (first descriptors) :nullable? true)})
+
+    :else
+    (schema-required! path :unsupported-value value)))
+
+
+(defn- infer-field
+  [records key]
+  (let [values      (keep #(when (contains? % key) (get % key)) records)
+        descriptors (mapv #(scalar-inference [key] %) (remove nil? values))]
+    (when (empty? descriptors)
+      (schema-required! [key] :all-null nil))
+    (when (> (count (distinct descriptors)) 1)
+      (schema-required! [key] :mixed-values (first (remove nil? values))))
+    (merge (first descriptors)
+           {:key       key
+            :name      (ds.utils/column-safe-name key)
+            :nullable? true})))
+
+
+(defn- ordered-field-keys
+  [records]
+  (:keys
+   (reduce
+    (fn [state record]
+      (reduce
+       (fn [state key]
+         (if (contains? (:seen state) key)
+           state
+           (-> state
+               (update :keys conj key)
+               (update :seen conj key))))
+       state
+       (clojure.core/keys record)))
+    {:keys [] :seen #{}}
+    records)))
+
+
+(defn infer-schema!
+  "Infer only deterministic scalar and homogeneous scalar-list task-result schemas."
+  [data]
+  (let [records (sample-records data)]
+    (when (seq records)
+      (when-not (every? map? records)
+        (schema-required! [] :non-record-result (first records)))
+      (normalize-schema
+       {:version schema-version
+        :fields  (mapv #(infer-field records %)
+                       (ordered-field-keys records))}))))
+
+
+(defn get-columns
+  "Best-effort schema inference for compatibility callers such as JDBC."
+  [data]
+  (try
+    (infer-schema! data)
+    (catch Exception _
+      nil)))
+
+
+(defn- field-type
+  [nullable? arrow-type metadata]
+  (FieldType. (boolean nullable?) ^ArrowType arrow-type nil metadata))
+
+
+(defn- scalar-arrow-type
+  [{:keys [type timezone]}]
+  (case type
+    :boolean (ArrowType$Bool.)
+    :uint8 (ArrowType$Int. 8 false)
+    :int8 (ArrowType$Int. 8 true)
+    :uint16 (ArrowType$Int. 16 false)
+    :int16 (ArrowType$Int. 16 true)
+    :uint32 (ArrowType$Int. 32 false)
+    :int32 (ArrowType$Int. 32 true)
+    :uint64 (ArrowType$Int. 64 false)
+    :int64 (ArrowType$Int. 64 true)
+    :float32 (ArrowType$FloatingPoint. FloatingPointPrecision/SINGLE)
+    :float64 (ArrowType$FloatingPoint. FloatingPointPrecision/DOUBLE)
+    :epoch-days (ArrowType$Date. DateUnit/DAY)
+    :local-date (ArrowType$Date. DateUnit/DAY)
+    :local-time (ArrowType$Time. TimeUnit/MICROSECOND (int 64))
+    :local-date-time (ArrowType$Timestamp. TimeUnit/MICROSECOND nil)
+    :time-nanoseconds (ArrowType$Time. TimeUnit/NANOSECOND (int 64))
+    :time-microseconds (ArrowType$Time. TimeUnit/MICROSECOND (int 64))
+    :time-milliseconds (ArrowType$Time. TimeUnit/MILLISECOND (int 32))
+    :time-seconds (ArrowType$Time. TimeUnit/SECOND (int 32))
+    :duration (ArrowType$Duration. TimeUnit/MICROSECOND)
+    :string (ArrowType$Utf8.)
+    :uuid (ArrowType$Utf8.)
+    :text (ArrowType$Utf8.)
+    :encoded-text (ArrowType$Utf8.)
+    :instant (ArrowType$Timestamp. TimeUnit/MICROSECOND timezone)
+    :epoch-milliseconds (ArrowType$Timestamp. TimeUnit/MILLISECOND timezone)
+    :epoch-microseconds (ArrowType$Timestamp. TimeUnit/MICROSECOND timezone)
+    :epoch-nanoseconds (ArrowType$Timestamp. TimeUnit/NANOSECOND timezone)))
+
+
+(defn- decimal-metadata
+  [descriptor]
+  (when (= :big-integer (:logical-type descriptor))
+    {"collet.logical-type" "big-integer"}))
+
+
+(defn descriptor->field
+  ([descriptor]
+   (descriptor->field descriptor "item"))
+  ([descriptor fallback-name]
+   (let [{:keys [type nullable? name] :as descriptor} (normalize-descriptor descriptor)
+         field-name (or name fallback-name)]
+     (case type
+       :struct
+       (Field. field-name
+               (field-type nullable? ArrowType$Struct/INSTANCE nil)
+               (mapv descriptor->field (:fields descriptor)))
+
+       :map
+       (Field. field-name
+               (field-type nullable? (ArrowType$Map. false) nil)
+               [(Field. "entries"
+                        (FieldType/notNullable ArrowType$Struct/INSTANCE)
+                        [(Field. "key"
+                                 (FieldType/notNullable (ArrowType$Utf8.))
+                                 nil)
+                         (Field. "value"
+                                 (FieldType/nullable (ArrowType$Utf8.))
+                                 nil)])])
+
+       :list
+       (Field. field-name
+               (field-type nullable? ArrowType$List/INSTANCE nil)
+               [(descriptor->field (:element descriptor) "item")])
+
+       :fixed-size-list
+       (Field. field-name
+               (field-type nullable?
+                           (ArrowType$FixedSizeList. (int (:size descriptor)))
+                           nil)
+               [(descriptor->field (:element descriptor) "item")])
+
+       :decimal
+       (Field. field-name
+               (field-type nullable?
+                           (ArrowType$Decimal. (int (:precision descriptor))
+                                               (int (:scale descriptor))
+                                               (int (:bit-width descriptor)))
+                           (decimal-metadata descriptor))
+               nil)
+
+       (Field. field-name
+               (field-type nullable? (scalar-arrow-type descriptor) nil)
+               nil)))))
+
+
+(defn create-zoned-field
+  [column-name column-type timezone]
+  (descriptor->field {:key      column-name
+                      :name     (str column-name)
+                      :type     column-type
+                      :timezone timezone}))
+
+
+(defn create-field
+  [column-name column-type]
+  (descriptor->field
+   (legacy-column->field [column-name (str column-name) column-type])))
+
+
+(defn create-schema
+  "Create an authoritative Arrow Schema from canonical or legacy columns."
+  [columns]
+  (let [schema (normalize-schema columns)]
+    (Schema. (mapv descriptor->field (:fields schema)))))
+
+
+(defn local-time->millis
+  ^Integer [^LocalTime time]
+  (let [seconds (.toSecondOfDay time)
+        nanos   (.getNano time)]
+    (int (+ (* seconds 1000) (quot nanos 1000000)))))
+
+
+(defn local-time->micros
+  ^long [^LocalTime time]
+  (let [seconds (.toSecondOfDay time)
+        nanos   (.getNano time)]
+    (+ (* seconds 1000000) (quot nanos 1000))))
+
+
+(defn duration->micros
+  ^long [^Duration duration]
+  (+ (* (.getSeconds duration) 1000000)
+     (quot (.getNano duration) 1000)))
+
+
+(defn instant->micros
+  ^long [^Instant instant]
+  (+ (* (.getEpochSecond instant) 1000000)
+     (quot (.getNano instant) 1000)))
+
+
+(defn date-time->micros
+  ^long [^LocalDateTime date-time]
+  (+ (* (.toEpochSecond date-time ZoneOffset/UTC) 1000000)
+     (quot (.getNano date-time) 1000)))
+
+
+(defn instant->nanos
+  ^long [^Instant instant]
+  (+ (* (.getEpochSecond instant) 1000000000)
+     (.getNano instant)))
+
+
+(defn write-list-item
+  "Compatibility writer used by existing callers of the legacy list helper."
+  [^UnionListWriter list-writer column-type item]
+  (case column-type
+    :boolean (.writeBit list-writer (if item 1 0))
+    :uint8 (.writeUInt1 list-writer (int item))
+    :int8 (.writeTinyInt list-writer (int item))
+    :uint16 (.writeUInt2 list-writer (int item))
+    :int16 (.writeSmallInt list-writer (int item))
+    :uint32 (.writeUInt4 list-writer (int item))
+    :int32 (.writeInt list-writer (int item))
+    :uint64 (.writeUInt8 list-writer (long item))
+    :int64 (.writeBigInt list-writer (long item))
+    :float32 (.writeFloat4 list-writer (float item))
+    :float64 (.writeFloat8 list-writer (double item))
+    :epoch-days (.writeDateDay list-writer (.toEpochDay ^LocalDate item))
+    :local-date (.writeDateDay list-writer (.toEpochDay ^LocalDate item))
+    :local-time (.writeTimeMicro list-writer (local-time->micros item))
+    :local-date-time (.writeTimeStampMicro list-writer (date-time->micros item))
+    :time-nanoseconds (.writeTimeNano list-writer (.toNanoOfDay ^LocalTime item))
+    :time-microseconds (.writeTimeMicro list-writer (local-time->micros item))
+    :time-milliseconds (.writeTimeMilli list-writer (local-time->millis item))
+    :time-seconds (.writeTimeSec list-writer (.toSecondOfDay ^LocalTime item))
+    :duration (.writeDuration list-writer (duration->micros item))
+    (:string :uuid :text :encoded-text) (.writeVarChar list-writer (str item))
+    :instant (.writeTimeStampMicro list-writer (instant->micros item))
+    :epoch-milliseconds (.writeTimeStampMilli list-writer (.toEpochMilli ^Instant item))
+    :epoch-microseconds (.writeTimeStampMicro list-writer (instant->micros item))
+    :epoch-nanoseconds (.writeTimeStampNano list-writer (instant->nanos item))
+    (schema-error! :unsupported-type
+                   (str "Unsupported Arrow list item type " (pr-str column-type) "."))))
+
+
+(defn- ->big-integer
+  [value]
+  (cond
+    (instance? BigInteger value)
+    value
+
+    (instance? BigInt value)
+    (.toBigInteger ^BigInt value)
+
+    (or (instance? Byte value)
+        (instance? Short value)
+        (instance? Integer value)
+        (instance? Long value))
+    (BigInteger/valueOf (long value))
+
+    :else
+    nil))
+
+
+(defn- integer-bounds
+  [type]
+  (let [[bits signed?] (case type
+                         :uint8 [8 false]
+                         :int8 [8 true]
+                         :uint16 [16 false]
+                         :int16 [16 true]
+                         :uint32 [32 false]
+                         :int32 [32 true]
+                         :uint64 [64 false]
+                         :int64 [64 true])]
+    (if signed?
+      [(.negate (.shiftLeft BigInteger/ONE (dec bits)))
+       (.subtract (.shiftLeft BigInteger/ONE (dec bits)) BigInteger/ONE)]
+      [BigInteger/ZERO
+       (.subtract (.shiftLeft BigInteger/ONE bits) BigInteger/ONE)])))
+
+
+(defn- checked-integer
+  [value type path descriptor]
+  (let [integer (->big-integer value)]
+    (when-not integer
+      (value-error! path descriptor :expected-integer value))
+    (let [[minimum maximum] (integer-bounds type)]
+      (when (or (neg? (.compareTo ^BigInteger integer minimum))
+                (pos? (.compareTo ^BigInteger integer maximum)))
+        (value-error! path descriptor :integer-overflow value)))
+    integer))
+
+
+(defn- mark!
+  [cursors arrow-vector end]
+  (swap! cursors update arrow-vector (fnil max 0) end))
+
+
+(defn- write-decimal!
+  [arrow-vector descriptor index value path]
+  (let [logical-type (:logical-type descriptor)
+        decimal      (cond
+                       (= logical-type :big-integer)
+                       (let [integer (or (when (instance? BigInteger value) value)
+                                         (when (instance? BigInt value)
+                                           (.toBigInteger ^BigInt value)))]
+                         (when-not integer
+                           (value-error! path descriptor :expected-big-integer value))
+                         (BigDecimal. ^BigInteger integer))
+
+                       (instance? BigDecimal value)
+                       value
+
+                       :else
+                       (value-error! path descriptor :expected-big-decimal value))
+        decimal      (try
+                       (.setScale ^BigDecimal decimal
+                                  (int (:scale descriptor))
+                                  RoundingMode/UNNECESSARY)
+                       (catch ArithmeticException _
+                         (value-error! path descriptor :rounding-required value)))]
+    (when (> (.precision ^BigDecimal decimal) (:precision descriptor))
+      (value-error! path descriptor :decimal-precision-exceeded value))
+    (if (= 128 (:bit-width descriptor))
+      (.setSafe ^DecimalVector arrow-vector (int index) ^BigDecimal decimal)
+      (.setSafe ^Decimal256Vector arrow-vector (int index) ^BigDecimal decimal))))
+
+
+(defn- write-scalar!
+  [arrow-vector {:keys [type] :as descriptor} index value path]
+  (when (instance? Date value)
+    (legacy-date-error! path value))
+  (case type
+    :boolean
+    (do
+      (when-not (instance? Boolean value)
+        (value-error! path descriptor :expected-boolean value))
+      (.setSafe ^BitVector arrow-vector (int index) (if value 1 0)))
+
+    :uint8
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^UInt1Vector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :int8
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^TinyIntVector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :uint16
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^UInt2Vector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :int16
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^SmallIntVector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :uint32
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^UInt4Vector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :int32
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^IntVector arrow-vector (int index) (.intValue ^BigInteger value)))
+
+    :uint64
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^UInt8Vector arrow-vector (int index) (.longValue ^BigInteger value)))
+
+    :int64
+    (let [value (checked-integer value type path descriptor)]
+      (.setSafe ^BigIntVector arrow-vector (int index) (.longValue ^BigInteger value)))
+
+    :float32
+    (do
+      (when-not (number? value)
+        (value-error! path descriptor :expected-number value))
+      (.setSafe ^Float4Vector arrow-vector (int index) (float value)))
+
+    :float64
+    (do
+      (when-not (number? value)
+        (value-error! path descriptor :expected-number value))
+      (.setSafe ^Float8Vector arrow-vector (int index) (double value)))
+
+    (:epoch-days :local-date)
+    (do
+      (when-not (instance? LocalDate value)
+        (value-error! path descriptor :expected-local-date value))
+      (.setSafe ^DateDayVector arrow-vector (int index) (.toEpochDay ^LocalDate value)))
+
+    :local-time
+    (do
+      (when-not (instance? LocalTime value)
+        (value-error! path descriptor :expected-local-time value))
+      (.setSafe ^TimeMicroVector arrow-vector (int index) (local-time->micros value)))
+
+    :local-date-time
+    (do
+      (when-not (instance? LocalDateTime value)
+        (value-error! path descriptor :expected-local-date-time value))
+      (.setSafe ^TimeStampMicroVector arrow-vector (int index) (date-time->micros value)))
+
+    :time-nanoseconds
+    (do
+      (when-not (instance? LocalTime value)
+        (value-error! path descriptor :expected-local-time value))
+      (.setSafe ^TimeNanoVector arrow-vector (int index) (.toNanoOfDay ^LocalTime value)))
+
+    :time-microseconds
+    (do
+      (when-not (instance? LocalTime value)
+        (value-error! path descriptor :expected-local-time value))
+      (.setSafe ^TimeMicroVector arrow-vector (int index) (local-time->micros value)))
+
+    :time-milliseconds
+    (do
+      (when-not (instance? LocalTime value)
+        (value-error! path descriptor :expected-local-time value))
+      (.setSafe ^TimeMilliVector arrow-vector (int index) (local-time->millis value)))
+
+    :time-seconds
+    (do
+      (when-not (instance? LocalTime value)
+        (value-error! path descriptor :expected-local-time value))
+      (.setSafe ^TimeSecVector arrow-vector (int index) (.toSecondOfDay ^LocalTime value)))
+
+    :duration
+    (do
+      (when-not (instance? Duration value)
+        (value-error! path descriptor :expected-duration value))
+      (.setSafe ^DurationVector arrow-vector (int index) (duration->micros value)))
+
+    (:string :uuid :text :encoded-text)
+    (.setSafe ^VarCharVector arrow-vector (int index) (Text. (str value)))
+
+    (:instant :epoch-microseconds)
+    (do
+      (when-not (instance? Instant value)
+        (value-error! path descriptor :expected-instant value))
+      (.setSafe ^TimeStampMicroVector arrow-vector (int index) (instant->micros value)))
+
+    :epoch-milliseconds
+    (do
+      (when-not (instance? Instant value)
+        (value-error! path descriptor :expected-instant value))
+      (.setSafe ^TimeStampMilliVector arrow-vector (int index) (.toEpochMilli ^Instant value)))
+
+    :epoch-nanoseconds
+    (do
+      (when-not (instance? Instant value)
+        (value-error! path descriptor :expected-instant value))
+      (.setSafe ^TimeStampNanoVector arrow-vector (int index) (instant->nanos value)))
+
+    :decimal
+    (write-decimal! arrow-vector descriptor index value path)))
+
+
+(defn- map-contains?
+  [value key]
+  (or (and (map? value) (contains? value key))
+      (and (instance? Map value)
+           (.containsKey ^Map value key))))
+
+
+(defn- field-value
+  [value field]
+  (let [keys [(:key field) (:name field) (keyword (:name field))]]
+    (or (some (fn [key]
+                (when (map-contains? value key)
+                  [true (get value key)]))
+              keys)
+        [false nil])))
+
+
+(defn- known-field-keys
+  [fields]
+  (set (mapcat (fn [{:keys [key name]}]
+                 [key name (keyword name)])
+        fields)))
+
+
+(declare write-value!)
+
+
+(defn- write-struct!
+  [^StructVector arrow-vector descriptor index value path cursors]
+  (when-not (map? value)
+    (value-error! path descriptor :expected-map value))
+  (let [fields  (:fields descriptor)
+        unknown (seq (remove (known-field-keys fields) (keys value)))]
+    (when unknown
+      (value-error! path descriptor :unknown-struct-key (first unknown)))
+    (.setIndexDefined arrow-vector (int index))
+    (doseq [field fields]
+      (let [[_ present-value] (field-value value field)
+            child             (.getChild arrow-vector ^String (:name field))]
+        (write-value! child field index present-value (conj path (:key field)) cursors)))))
+
+
+(defn- write-map!
+  [^MapVector arrow-vector descriptor index value path cursors]
+  (when-not (map? value)
+    (value-error! path descriptor :expected-map value))
+  (let [entries-vector ^StructVector (.getDataVector arrow-vector)
+        key-vector     (.getChild entries-vector "key")
+        value-vector   (.getChild entries-vector "value")
+        start          (.startNewValue arrow-vector (int index))
+        key-desc       (:key-type descriptor)
+        value-desc     (:value-type descriptor)
+        size           (loop [entry-seq   (seq value)
+                              entry-index start
+                              size        0]
+                         (if-let [[entry-key entry-value] (first entry-seq)]
+                           (do
+                             (when-not (string? entry-key)
+                               (value-error! (conj path entry-key)
+                                             key-desc
+                                             :map-key-not-string
+                                             entry-key))
+                             (when (and (some? entry-value)
+                                        (not (string? entry-value)))
+                               (value-error! (conj path entry-key)
+                                             value-desc
+                                             :map-value-not-string
+                                             entry-value))
+                             (.setIndexDefined entries-vector (int entry-index))
+                             (write-value! key-vector
+                                           key-desc
+                                           entry-index
+                                           entry-key
+                                           (conj path entry-key)
+                                           cursors)
+                             (write-value! value-vector
+                                           value-desc
+                                           entry-index
+                                           entry-value
+                                           (conj path entry-key)
+                                           cursors)
+                             (mark! cursors entries-vector (inc entry-index))
+                             (recur (next entry-seq) (inc entry-index) (inc size)))
+                           size))]
+    (.endValue arrow-vector (int index) size)))
+
+
+(defn- write-list!
+  [^ListVector arrow-vector descriptor index value path cursors]
+  (when-not (and (sequential? value) (not (string? value)))
+    (value-error! path descriptor :expected-sequential value))
+  (let [child (.getDataVector arrow-vector)
+        start (.startNewValue arrow-vector (int index))
+        size  (loop [items      (seq value)
+                     item-index start
+                     count      0]
+                (if (seq items)
+                  (let [item (first items)]
+                    (write-value! child
+                                  (:element descriptor)
+                                  item-index
+                                  item
+                                  (conj path count)
+                                  cursors)
+                    (recur (next items) (inc item-index) (inc count)))
+                  count))]
+    (.endValue arrow-vector (int index) size)))
+
+
+(defn- fixed-items
+  [value size path descriptor]
+  (when-not (and (sequential? value) (not (string? value)))
+    (value-error! path descriptor :expected-sequential value))
+  (let [items (vec (take (inc size) value))]
+    (when-not (= size (count items))
+      (value-error! path descriptor :wrong-fixed-size value))
+    items))
+
+
+(defn- write-fixed-size-list!
+  [^FixedSizeListVector arrow-vector descriptor index value path cursors]
+  (let [size  (:size descriptor)
+        items (fixed-items value size path descriptor)
+        child (.getDataVector arrow-vector)
+        start (* index size)]
+    (.setNotNull arrow-vector (int index))
+    (doseq [[item-index item] (map-indexed clojure.core/vector items)]
+      (write-value! child
+                    (:element descriptor)
+                    (+ start item-index)
+                    item
+                    (conj path item-index)
+                    cursors))))
+
+
+(defn- write-value!
+  [^FieldVector arrow-vector descriptor index value path cursors]
+  (if (nil? value)
+    (if (:nullable? descriptor)
+      (do
+        (.setNull arrow-vector (int index))
+        (mark! cursors arrow-vector (inc index)))
+      (value-error! path descriptor :non-nullable nil))
+    (do
+      (case (:type descriptor)
+        :struct (write-struct! ^StructVector arrow-vector descriptor index value path cursors)
+        :map (write-map! ^MapVector arrow-vector descriptor index value path cursors)
+        :list (write-list! ^ListVector arrow-vector descriptor index value path cursors)
+        :fixed-size-list (write-fixed-size-list! ^FixedSizeListVector arrow-vector descriptor index value path cursors)
+        (write-scalar! arrow-vector descriptor index value path))
+      (mark! cursors arrow-vector (inc index)))))
+
+
+(declare finish-vector!)
+
+
+(defn- finish-map-vector!
+  [^MapVector arrow-vector descriptor count cursors]
+  (let [entries      ^StructVector (.getDataVector arrow-vector)
+        key-vector   (.getChild entries "key")
+        value-vector (.getChild entries "value")
+        entry-count  (get @cursors entries 0)]
+    (finish-vector! key-vector (:key-type descriptor) entry-count cursors)
+    (finish-vector! value-vector (:value-type descriptor) entry-count cursors)
+    (.setValueCount entries entry-count)
+    (.setValueCount arrow-vector (int count))))
+
+
+(defn- finish-vector!
+  [^FieldVector arrow-vector descriptor count cursors]
+  (case (:type descriptor)
+    :struct
+    (do
+      (doseq [field (:fields descriptor)]
+        (finish-vector! (.getChild ^StructVector arrow-vector ^String (:name field))
+                        field
+                        count
+                        cursors))
+      (.setValueCount arrow-vector (int count)))
+
+    :map
+    (finish-map-vector! ^MapVector arrow-vector descriptor count cursors)
+
+    :list
+    (do
+      (finish-vector! (.getDataVector ^ListVector arrow-vector)
+                      (:element descriptor)
+                      (get @cursors (.getDataVector ^ListVector arrow-vector) 0)
+                      cursors)
+      (.setValueCount arrow-vector (int count)))
+
+    :fixed-size-list
+    (do
+      (finish-vector! (.getDataVector ^FixedSizeListVector arrow-vector)
+                      (:element descriptor)
+                      (* count (:size descriptor))
+                      cursors)
+      (.setValueCount arrow-vector (int count)))
+
+    (.setValueCount arrow-vector (int count))))
+
+
+(defn- allocate-vector!
+  [^FieldVector arrow-vector batch-size]
+  (.setInitialCapacity arrow-vector (int batch-size))
+  (.allocateNew arrow-vector))
 
 
 (defn set-column-vector
-  "Write data to a single column vector of specified type."
-  [{:keys [^VectorSchemaRoot schema-root ^String column-name column-type column batch-size]}]
-  (cond
-    (and (vector? column-type) (= :list (first column-type)))
-    (let [vector      ^ListVector (.getVector schema-root column-name)
-          list-writer ^UnionListWriter (.getWriter vector)]
-      (doall
-       (map-indexed
-        (fn [idx list]
-          (.setPosition list-writer idx)
-          (if (or (nil? list) (empty? list))
-            (.writeNull list-writer)
-            (do (.startList list-writer)
-                (doseq [item list]
-                  (write-list-item list-writer (second column-type) item))
-                (.endList list-writer))))
-        column))
-      (.setValueCount vector batch-size))
-
-    (and (vector? column-type) (= :zoned (first column-type)))
-    (let [vector (.getVector schema-root column-name)]
-      (.allocateNew ^BaseFixedWidthVector vector batch-size)
-      (doall
-       (map-indexed
-        (fn [^long idx value]
-          (case (second column-type)
-            (:instant :epoch-microseconds)
-            (.set ^TimeStampMicroVector vector idx (instant->micros value))
-            :epoch-milliseconds
-            (.set ^TimeStampMilliVector vector idx (.toEpochMilli ^Instant value))
-            :epoch-nanoseconds
-            (.set ^TimeStampNanoVector vector idx (instant->nanos value))
-            ;; default case if no match
-            (throw (ex-info "Unsupported column type" {:column-type column-type}))))
-        column)))
-
-    :otherwise
-    (let [vector (.getVector schema-root column-name)]
-      (if (contains? varchar-types column-type)
-        (.allocateNew ^BaseVariableWidthVector vector batch-size)
-        (.allocateNew ^BaseFixedWidthVector vector batch-size))
-      (doall
-       (map-indexed
-        (fn [^long idx value]
-          (if (nil? value)
-            (.setNull vector idx)
-            (case column-type
-              :boolean (.setSafe ^BitVector vector idx (if value 1 0))
-              (:uint8 :int8) (.setSafe ^IntVector vector idx (int value))
-              (:uint16 :int16) (.setSafe ^IntVector vector idx (int value))
-              (:uint32 :int32) (.setSafe ^IntVector vector idx (int value))
-              (:uint64 :int64) (.setSafe ^BigIntVector vector idx (long value))
-              :float32 (.setSafe ^Float4Vector vector idx (float value))
-              :float64 (.setSafe ^Float8Vector vector idx (double value))
-              (:epoch-days :local-date) (.setSafe ^DateDayVector vector idx (.toEpochDay ^LocalDate value))
-              :local-time (.setSafe ^TimeMicroVector vector idx (local-time->micros value))
-              :local-date-time (.setSafe ^TimeStampMicroVector vector idx (date-time->micros value))
-              :time-nanoseconds (.setSafe ^TimeNanoVector vector idx (.toNanoOfDay ^LocalTime value))
-              :time-microseconds (.setSafe ^TimeMicroVector vector idx (local-time->micros value))
-              :time-milliseconds (.setSafe ^TimeMilliVector vector idx (local-time->millis value))
-              :time-seconds (.setSafe ^TimeSecVector vector idx (.toSecondOfDay ^LocalTime value))
-              :duration (.setSafe ^DurationVector vector idx (duration->micros value))
-              (:string :uuid :text :encoded-text)
-              (.setSafe ^VarCharVector vector idx (Text. (str value)))
-              ;; default case if no match
-              (throw (ex-info "Unsupported column type" {:column-type column-type})))))
-        column)))))
+  "Write one canonical or legacy column into its Arrow field vector."
+  [{:keys [^VectorSchemaRoot schema-root column-name column-type column batch-size]}]
+  (let [descriptor   (if (and (map? column-type)
+                              (contains? column-type :key)
+                              (contains? column-type :name))
+                       (normalize-field column-type)
+                       (legacy-column->field [(keyword column-name) column-name column-type]))
+        arrow-vector (.getVector schema-root ^String column-name)
+        cursors      (atom {})]
+    (allocate-vector! arrow-vector batch-size)
+    (doseq [[index value] (map-indexed clojure.core/vector column)]
+      (write-value! arrow-vector descriptor index value [index (:key descriptor)] cursors))
+    (finish-vector! arrow-vector descriptor batch-size cursors)))
 
 
 (defn get-batch-size
@@ -340,115 +1486,435 @@
     (count batch)))
 
 
+(defn- record-field-value
+  [record field]
+  (let [[present? value] (field-value record field)]
+    (when present?
+      value)))
+
+
+(declare prep-value)
+
+
 (defn set-vectors-data
-  "Write data to all columns of the schema."
+  "Write all fields in a record batch using its authoritative schema."
   [^VectorSchemaRoot schema-root columns batch]
-  (let [batch-size (get-batch-size batch)
-        ds?        (ds/dataset? batch)]
-    (doseq [[column-key column-name column-type] columns]
-      (set-column-vector
-       {:schema-root schema-root
-        :column-name column-name
-        :column-type column-type
-        :column      (if ds?
-                       (get batch column-key)
-                       (map #(get % column-key) batch))
-        :batch-size  batch-size}))))
+  (let [schema     (normalize-schema columns)
+        batch-size (get-batch-size batch)
+        dataset?   (ds/dataset? batch)]
+    (doseq [field (:fields schema)]
+      (let [column (if dataset?
+                     (map #(prep-value % field)
+                          (or (get batch (:key field))
+                              (get batch (keyword (:name field)))
+                              (repeat batch-size nil)))
+                     (map #(record-field-value % field) batch))]
+        (set-column-vector
+         {:schema-root schema-root
+          :column-name (:name field)
+          :column-type field
+          :column      column
+          :batch-size  batch-size})))))
 
 
 (defprotocol PWriter
   (write [this batch]))
 
 
-(defn ^Closeable make-writer
-  "Create an Arrow file writer. This function returns a writer object with `write` and `close` methods.
-   Write methods accepts a batch of data to write to the Arrow file."
+(defn make-writer
+  "Create an Arrow IPC writer for canonical or legacy columns."
   [file-or-path columns]
-  (let [allocator     (RootAllocator.)
-        schema        (create-schema columns)
-        schema-root   (VectorSchemaRoot/create schema allocator)
+  (let [schema        (normalize-schema columns)
+        allocator     (RootAllocator.)
+        arrow-schema  (create-schema schema)
+        schema-root   (VectorSchemaRoot/create arrow-schema allocator)
         output-stream (if (instance? File file-or-path)
                         (FileOutputStream. ^File file-or-path)
-                        (FileOutputStream. ^String file-or-path))
+                        (FileOutputStream. (str file-or-path)))
         writer        (ArrowFileWriter. schema-root nil (.getChannel output-stream))]
     (.start writer)
-
     (reify
-      PWriter
-      (write [this batch]
-        (let [batch-size (get-batch-size batch)]
-          (when (> batch-size 0)
-            (try
-              (set-vectors-data schema-root columns batch)
-              (.setRowCount schema-root batch-size)
-              (.writeBatch writer)
-              (catch Exception e
-                (throw (ex-info "Error writing Arrow file"
-                                {:file    file-or-path
-                                 :columns columns
-                                 :batch   batch}
-                                e)))))))
-      Closeable
-      (close [this]
-        (.end writer)
-        (.close writer)
-        (.close output-stream)
-        (.close schema-root)
-        (.close allocator)))))
+     PWriter
+     (write [_ batch]
+       (let [batch-size (get-batch-size batch)]
+         (when (pos? batch-size)
+           (try
+             (set-vectors-data schema-root schema batch)
+             (.setRowCount schema-root batch-size)
+             (.writeBatch writer)
+             (catch ExceptionInfo error
+               (if (:collet.error/type (ex-data error))
+                 (throw error)
+                 (throw
+                  (ex-info "Error writing Arrow file."
+                           {:file   file-or-path
+                            :schema schema}
+                           error))))
+             (catch Exception error
+               (throw
+                (ex-info "Error writing Arrow file."
+                         {:file   file-or-path
+                          :schema schema}
+                         error)))))))
+
+     Closeable
+     (close [_]
+       (.end writer)
+       (.close writer)
+       (.close output-stream)
+       (.close schema-root)
+       (.close allocator)))))
 
 
-(defn vec-or-nil [x]
-  (when (some? x)
-    (vec x)))
+(defn- file-path
+  [file-or-path]
+  (cond
+    (instance? File file-or-path)
+    (.toPath ^File file-or-path)
+
+    (instance? Path file-or-path)
+    file-or-path
+
+    :else
+    (Paths/get (str file-or-path) (make-array String 0))))
 
 
-(defn instant->local-date-time
-  [^Instant x]
-  (LocalDateTime/ofInstant x ZoneOffset/UTC))
+(defn- read-channel
+  [path]
+  (FileChannel/open ^Path path
+                    (into-array OpenOption [StandardOpenOption/READ])))
 
 
-(defn read-dataset
-  "Read an Arrow file and return a dataset.
-   If the file contains multiple datasets, they will be concatenated."
-  [file-or-path columns]
-  (let [path (if (instance? File file-or-path)
-               (.toPath ^File file-or-path)
-               file-or-path)]
-    (with-meta (arrow/stream->dataset-seq path {:open-type :mmap :key-fn keyword})
-               {:ds-seq        true
-                :arrow-columns columns})))
+(defn- validate-file-schema!
+  [path expected-schema]
+  (with-open [allocator (RootAllocator.)
+              channel   (read-channel path)
+              reader    (ArrowFileReader. ^SeekableByteChannel channel allocator)]
+    (let [actual-schema (.getSchema (.getVectorSchemaRoot reader))]
+      (when-not (= expected-schema actual-schema)
+        (arrow-error!
+         :collet.error/arrow-schema-mismatch
+         "Arrow IPC schema differs from the declared schema."
+         {:expected (str expected-schema)
+          :actual   (str actual-schema)})))))
+
+
+(defn- object-column-schema?
+  [descriptor]
+  (case (:type descriptor)
+    :struct true
+    :map true
+    :fixed-size-list true
+    :decimal true
+    :list true
+    false))
+
+
+(defn- nested-schema?
+  [schema]
+  (boolean (some object-column-schema? (:fields schema))))
 
 
 (defn micros->duration
-  [^long micros]
-  (Duration/ofNanos (* micros 1000)))
+  [micros]
+  (Duration/ofNanos (* (long micros) 1000)))
+
+
+(defn- micros->instant
+  [micros]
+  (Instant/ofEpochSecond (quot (long micros) 1000000)
+                         (* (rem (long micros) 1000000) 1000)))
+
+
+(defn- raw-map-value
+  [value field]
+  (second (field-value value field)))
+
+
+(defn- unsigned-value
+  [type value]
+  (let [value (long value)]
+    (case type
+      :uint8 (bit-and value 0xff)
+      :uint16 (bit-and value 0xffff)
+      :uint32 (Integer/toUnsignedLong (int value))
+      :uint64 (let [integer (BigInteger/valueOf value)]
+                (if (neg? value)
+                  (.add integer (.shiftLeft BigInteger/ONE 64))
+                  integer)))))
+
+
+(declare logical-value)
+
+
+(defn- logical-scalar
+  [descriptor value]
+  (let [type (:type descriptor)]
+    (cond
+      (nil? value)
+      nil
+
+      (= :uuid type)
+      (if (instance? UUID value)
+        value
+        (parse-uuid (str value)))
+
+      (contains? varchar-types type)
+      (str value)
+
+      (contains? #{:uint8 :uint16 :uint32 :uint64} type)
+      (unsigned-value type value)
+
+      (= :epoch-days type)
+      (if (instance? LocalDate value)
+        value
+        (LocalDate/ofEpochDay (long value)))
+
+      (= :local-date type)
+      (if (instance? LocalDate value)
+        value
+        (LocalDate/ofEpochDay (long value)))
+
+      (= :local-time type)
+      (if (instance? LocalTime value)
+        value
+        (LocalTime/ofNanoOfDay (* (long value) 1000)))
+
+      (= :time-nanoseconds type)
+      (if (instance? LocalTime value)
+        value
+        (LocalTime/ofNanoOfDay (long value)))
+
+      (= :time-microseconds type)
+      (if (instance? LocalTime value)
+        value
+        (LocalTime/ofNanoOfDay (* (long value) 1000)))
+
+      (= :time-milliseconds type)
+      (if (instance? LocalTime value)
+        value
+        (LocalTime/ofNanoOfDay (* (long value) 1000000)))
+
+      (= :time-seconds type)
+      (if (instance? LocalTime value)
+        value
+        (LocalTime/ofSecondOfDay (long value)))
+
+      (= :duration type)
+      (if (instance? Duration value)
+        value
+        (micros->duration value))
+
+      (= :local-date-time type)
+      (cond
+        (instance? LocalDateTime value)
+        value
+
+        (instance? Instant value)
+        (LocalDateTime/ofInstant ^Instant value ZoneOffset/UTC)
+
+        :else
+        (LocalDateTime/ofInstant (micros->instant value) ZoneOffset/UTC))
+
+      (= :instant type)
+      (cond
+        (instance? Instant value)
+        value
+
+        (instance? LocalDateTime value)
+        (.toInstant ^LocalDateTime value ZoneOffset/UTC)
+
+        :else
+        (micros->instant value))
+
+      (= :epoch-milliseconds type)
+      (if (instance? Instant value)
+        value
+        (Instant/ofEpochMilli (long value)))
+
+      (= :epoch-microseconds type)
+      (if (instance? Instant value)
+        value
+        (micros->instant value))
+
+      (= :epoch-nanoseconds type)
+      (if (instance? Instant value)
+        value
+        (Instant/ofEpochSecond (quot (long value) 1000000000)
+                               (rem (long value) 1000000000)))
+
+      :else
+      value)))
+
+
+(defn logical-value
+  "Convert an Arrow vector object into the declared logical Clojure value."
+  [descriptor value]
+  (let [descriptor (normalize-descriptor descriptor)]
+    (if (nil? value)
+      nil
+      (case (:type descriptor)
+        :struct
+        (reduce
+         (fn [result field]
+           (assoc result
+             (:key field)
+             (logical-value field (raw-map-value value field))))
+         {}
+         (:fields descriptor))
+
+        :map
+        (into {}
+              (map (fn [entry]
+                     [(logical-value (:key-type descriptor)
+                                     (raw-map-value entry {:key "key" :name "key"}))
+                      (logical-value (:value-type descriptor)
+                                     (raw-map-value entry {:key "value" :name "value"}))]))
+              value)
+
+        :list
+        (mapv #(logical-value (:element descriptor) %) value)
+
+        :fixed-size-list
+        (mapv #(logical-value (:element descriptor) %) value)
+
+        :decimal
+        (let [decimal (if (instance? BigDecimal value)
+                        value
+                        (BigDecimal. (str value)))]
+          (if (= :big-integer (:logical-type descriptor))
+            (.toBigIntegerExact decimal)
+            decimal))
+
+        (logical-scalar descriptor value)))))
+
+
+(defn- root->dataset
+  [^VectorSchemaRoot root schema]
+  (let [fields (:fields schema)
+        rows   (mapv
+                (fn [index]
+                  (reduce
+                   (fn [record field]
+                     (let [arrow-vector (.getVector root ^String (:name field))]
+                       (assoc record
+                         (:key field)
+                         (logical-value field (.getObject arrow-vector index)))))
+                   {}
+                   fields))
+                (range (.getRowCount root)))]
+    (with-meta (ds/->dataset rows)
+               {:arrow-columns schema})))
+
+
+(defn- close-quietly!
+  [closeable]
+  (try
+    (.close ^AutoCloseable closeable)
+    (catch Exception _
+      nil)))
+
+
+(defn- nested-dataset-seq
+  [path schema]
+  (let [allocator (RootAllocator.)
+        channel   (read-channel path)
+        reader    (ArrowFileReader. ^SeekableByteChannel channel allocator)
+        closed?   (atom false)
+        close!    (fn []
+                    (when (compare-and-set! closed? false true)
+                      (close-quietly! reader)
+                      (close-quietly! channel)
+                      (close-quietly! allocator)))
+        step      (fn step []
+                    (lazy-seq
+                     (try
+                       (if (.loadNextBatch reader)
+                         (cons (root->dataset (.getVectorSchemaRoot reader) schema)
+                               (step))
+                         (do
+                           (close!)
+                           nil))
+                       (catch Throwable error
+                         (close!)
+                         (throw error)))))]
+    (resource/track
+     (step)
+     {:track-type :gc
+      :dispose-fn close!})))
+
+
+(defn read-dataset
+  "Read an IPC file as TMD datasets with canonical Arrow schema metadata."
+  [file-or-path columns]
+  (let [schema       (normalize-schema columns)
+        arrow-schema (create-schema schema)
+        path         (file-path file-or-path)]
+    (validate-file-schema! path arrow-schema)
+    (with-meta
+      (if (nested-schema? schema)
+        (nested-dataset-seq path schema)
+        (arrow/stream->dataset-seq path {:open-type :mmap :key-fn keyword}))
+      {:ds-seq        true
+       :arrow-columns schema})))
+
+
+(defn- logical-nested-value?
+  [field value]
+  (case (:type field)
+    :map
+    (map? value)
+
+    :struct
+    (and (map? value)
+         (some #(map-contains? value (:key %)) (:fields field)))
+
+    :list
+    (let [element (:element field)]
+      (and (sequential? value)
+           (some #(logical-nested-value? element %) (remove nil? value))))
+
+    :fixed-size-list
+    (and (sequential? value)
+         (some? value))
+
+    false))
 
 
 (defn prep-value
-  [value [_column-key _column-name column-type]]
-  (cond (= column-type :string)
-        (str value)
-
-        (= column-type :local-date-time)
-        (instant->local-date-time value)
-
-        (= column-type :uuid)
-        (-> value str parse-uuid)
-
-        (and (vector? column-type) (= :list (first column-type)))
-        (vec-or-nil value)
-
-        (= column-type :duration)
-        (micros->duration value)
-
-        :otherwise value))
+  [value column]
+  (let [field (if (and (vector? column) (= 3 (count column)))
+                (legacy-column->field column)
+                (normalize-descriptor column))
+        value (if (logical-nested-value? field value)
+                value
+                (logical-value field value))]
+    (if (and (= :uuid (:type field))
+             (some? value)
+             (not (instance? UUID value)))
+      (parse-uuid (str value))
+      value)))
 
 
 (defn prep-record
+  "Restore logical values and top-level nil keys from canonical Arrow metadata."
   [record columns]
   (reduce
-   (fn [r [_column-key column-name _column-type :as column]]
-     (let [column-key (keyword column-name)]
-       (update r column-key prep-value column)))
+   (fn [result field]
+     (let [physical-key     (keyword (:name field))
+           target-key       (:key field)
+           [present? value] (if (contains? result target-key)
+                              [true (get result target-key)]
+                              (if (contains? result physical-key)
+                                [true (get result physical-key)]
+                                [false nil]))
+           result           (assoc result
+                              target-key
+                              (if present?
+                                (prep-value value field)
+                                nil))]
+       (if (= target-key physical-key)
+         result
+         (dissoc result physical-key))))
    record
-   columns))
+   (schema-fields columns)))

--- a/collet-core/src/collet/core.clj
+++ b/collet-core/src/collet/core.clj
@@ -713,6 +713,77 @@
    (.-columns arrow-task-result)))
 
 
+(def ^:private arrow-batch-size 4096)
+
+
+(defn- batch-candidate?
+  [batch]
+  (or (ds/dataset? batch)
+      (sequential? batch)))
+
+
+(defn- nonempty-batch?
+  [batch]
+  (and (batch-candidate? batch)
+       (pos? (collet.arrow/get-batch-size batch))))
+
+
+(defn- record-batch?
+  [batch]
+  (or (ds/dataset? batch)
+      (and (sequential? batch)
+           (let [row (first batch)]
+             (or (nil? row) (map? row))))))
+
+
+(defn- result-layout
+  [data]
+  (let [sampled-item (first (drop-while nil? (take 200 data)))
+        batches?     (record-batch? sampled-item)]
+    ;; An empty batch establishes batched shape but cannot supply schema
+    ;; metadata, so locate the first non-empty batch separately.
+    {:batches?    batches?
+     :first-batch (when batches?
+                    (first (filter nonempty-batch? data)))}))
+
+
+(defn- skip-arrow-conversion?
+  [data]
+  (true? (-> data meta :collet.arrow/skip-conversion?)))
+
+
+(defn- result-schema
+  [data batches? first-batch]
+  (let [explicit-schema (or (-> data meta :arrow-columns)
+                            (-> first-batch meta :arrow-columns))]
+    (if explicit-schema
+      (collet.arrow/normalize-schema explicit-schema)
+      (let [records (if batches?
+                      (mapcat #(if (ds/dataset? %) (ds/rows %) %) data)
+                      data)
+            inference-candidate?
+            (if-some [record (first (remove nil? (take 200 records)))]
+              (map? record)
+              true)]
+        (when inference-candidate?
+          (collet.arrow/infer-schema! records))))))
+
+
+(defn- write-arrow-result!
+  [task-name data schema batches?]
+  (let [file ^File (File/createTempFile (name task-name) ".arrow")]
+    (.deleteOnExit file)
+    (with-open [writer (collet.arrow/make-writer file schema)]
+      (if batches?
+        (doseq [batch data
+                :when (nonempty-batch? batch)]
+          (collet.arrow/write writer batch))
+        (doseq [batch (partition-all arrow-batch-size data)
+                :when (nonempty-batch? batch)]
+          (collet.arrow/write writer batch))))
+    (ArrowTaskResult. task-name schema file)))
+
+
 (defn handle-task-result
   [task-name data {:keys [use-arrow keep-result]}]
   (if (not (sequential? data))
@@ -721,26 +792,13 @@
     ;; process as a sequence
     (cond
       (and keep-result use-arrow)
-      (let [seq-items?    (sequential? (first data))
-            arrow-columns (if seq-items?
-                            (collet.arrow/get-columns (first data))
-                            (collet.arrow/get-columns data))]
-        (if (some? arrow-columns)
-          ;; write to arrow file
-          (let [file ^File (File/createTempFile (name task-name) ".arrow")]
-            (.deleteOnExit file)
-            (with-open [writer (collet.arrow/make-writer file arrow-columns)]
-              (if seq-items?
-                (loop [batch     (first data)
-                       remaining (rest data)]
-                  (when (some? batch)
-                    (collet.arrow/write writer batch)
-                    (recur (first remaining) (rest remaining))))
-                ;; TODO add batching for flat sequences
-                (collet.arrow/write writer data)))
-            (ArrowTaskResult. task-name arrow-columns file))
-          ;; return as is
-          (doall data)))
+      (if (skip-arrow-conversion? data)
+        (doall data)
+        (let [{:keys [batches? first-batch]} (result-layout data)
+              schema (result-schema data batches? first-batch)]
+          (if schema
+            (write-arrow-result! task-name data schema batches?)
+            (doall data))))
 
       keep-result
       (doall data)

--- a/collet-core/test/collet/actions/enrich_test.clj
+++ b/collet-core/test/collet/actions/enrich_test.clj
@@ -1,17 +1,17 @@
 (ns collet.actions.enrich-test
   (:require
    [clojure.test :refer :all]
-   [collet.core :as collet]
    [collet.actions.enrich :as sut]
-   [collet.test-http-server :as http]
+   [collet.core :as collet]
+   [collet.store.datalevin :as datalevin]
    [collet.test-fixtures :as tf]
-   [collet.utils :as utils]
-   [collet.store.datalevin :as datalevin]))
+   [collet.test-http-server :as http]
+   [collet.utils :as utils]))
 
 
 (use-fixtures :once
-  http/with-server
-  (tf/instrument! 'collet.actions.enrich))
+              http/with-server
+              (tf/instrument! 'collet.actions.enrich))
 
 
 (defn- run-durable-pipeline
@@ -24,20 +24,150 @@
       @run
       run
       (finally
-        (collet/close ctx)))))
+       (collet/close ctx)))))
 
 
 (def test-events-data
-  [[{:id "9a624d46-8cca-43bf-a58a-f8f21a2f98d8", :type "Concert", :score 100, :name "Alice Cooper at Grand Casino Hinckley Events & Convention Center", :life-span {:begin "2017-06-08", :end "2017-06-08"}, :time "20:00:00", :relations [{:type "support act", :type-id "492a850e-97eb-306a-a85e-4b6d98527796", :direction "backward", :artist {:id "bd6b6464-0cf5-48d9-8b7f-52d88d4e87f0", :name "Chris Hawkey", :sort-name "Chris Hawkey"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "ee58c59f-8e7f-4430-b8ca-236c4d3745ae", :name "Alice Cooper", :sort-name "Cooper, Alice", :disambiguation "the musician born Vincent Damon Furnier, changed his name legally to Alice Cooper in 1974"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "8cfeea3a-132e-47f0-aaf5-d7f908f02f86", :name "Grand Casino Hinckley Amphitheater"}}]}
-    {:id "a824bfa5-ed32-4b2a-82c4-8c9045d311b1", :type "Concert", :score 100, :name "Lost In The Manor - Old Queen's Head, Angel, London", :life-span {:begin "2016-09-18", :end "2016-09-18"}, :time "18:30:00", :relations [{:type "held in", :type-id "542f8484-8bc7-3ce5-a022-747850b2b928", :direction "backward", :area {:id "f03d09b3-39dc-4083-afd6-159e3f0d462f", :name "London"}}]}
-    {:id "5e98db6f-6132-4190-881c-acdf2ea94b59", :type "Concert", :score 100, :name "Queensrÿche at 日本青年館", :life-span {:begin "1984-08-03", :end "1984-08-03"}, :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "deeea939-7f89-4762-b09f-79269cd70d3b", :name "Queensrÿche", :sort-name "Queensrÿche"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "4f21f35e-6d44-493a-93a2-94f1ac712c14", :name "日本青年館"}}]}
-    {:id "a91fac23-3d87-4bdb-a89e-abcccea8c200", :type "Concert", :score 100, :name "1971‐11‐12: Student Prince, Asbury Park, NJ, USA", :disambiguation "The Bruce Springsteen Band", :life-span {:begin "1971-11-12", :end "1971-11-13"}, :time "21:30:00", :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "70248960-cb53-4ea4-943a-edb18f7d336f", :name "Bruce Springsteen", :sort-name "Springsteen, Bruce"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "1607e961-c4a7-4602-ac22-d0d87833eee3", :name "The Bruce Springsteen Band", :sort-name "Bruce Springsteen Band, The"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6", :name "Student Prince"}}]}
-    {:id "be5782a4-1bfe-4d03-8fd1-39e54b77bb80", :type "Concert", :score 100, :name "1971‐11‐21: Student Prince, Asbury Park, NJ, USA", :disambiguation "The Bruce Springsteen Band", :life-span {:begin "1971-11-21", :end "1971-11-22"}, :time "21:30:00", :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "70248960-cb53-4ea4-943a-edb18f7d336f", :name "Bruce Springsteen", :sort-name "Springsteen, Bruce"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "1607e961-c4a7-4602-ac22-d0d87833eee3", :name "The Bruce Springsteen Band", :sort-name "Bruce Springsteen Band, The"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6", :name "Student Prince"}}]}]
-   [{:id "69f7153a-2fff-425a-9b00-e02f14b54f2b", :type "Concert", :score 100, :name "1971‐11‐23: New Plaza Theater, Linden, NJ, USA", :disambiguation "jam session", :life-span {:begin "1971-11-23", :end "1971-11-23"}, :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "23ab1c9b-5295-404d-9143-80e06b93341e", :name "Psychotic Blues Band", :sort-name "Band, Psychotic Blues", :disambiguation "New Jersey"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "051f7534-cad4-4f7f-a5ef-7403b1fcee02", :name "Tumbleweed", :sort-name "Tumbleweed", :disambiguation "New Jersey"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "5ba1e8d6-7c62-477e-bf01-10ef3048eb68", :name "Pat Karwin", :sort-name "Karwin, Pat"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "4cda092b-95fb-45fc-ae29-5830c82bf036", :name "Taylors Mills Road", :sort-name "Road, Taylors Mills"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "41a8f637-21f3-408c-a1d8-972bea1523e2", :name "The Rich Baron Band", :sort-name "Rich Baron Band, The"}} {:type "guest performer", :type-id "292df906-98a6-307e-86e8-df01a579a321", :direction "backward", :artist {:id "70248960-cb53-4ea4-943a-edb18f7d336f", :name "Bruce Springsteen", :sort-name "Springsteen, Bruce"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "cfe59d21-9ede-45ef-b6e4-21b6fa3e433b", :name "New Plaza Theater"}}]}
-    {:id "c7c94544-5693-4569-8927-53f03b7c1be3", :type "Concert", :score 100, :name "1971‐11‐28: Student Prince, Asbury Park, NJ, USA", :disambiguation "The Bruce Springsteen Band", :life-span {:begin "1971-11-28", :end "1971-11-29"}, :time "21:30:00", :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "70248960-cb53-4ea4-943a-edb18f7d336f", :name "Bruce Springsteen", :sort-name "Springsteen, Bruce"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "1607e961-c4a7-4602-ac22-d0d87833eee3", :name "The Bruce Springsteen Band", :sort-name "Bruce Springsteen Band, The"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6", :name "Student Prince"}}]}
-    {:id "807f3f14-f3b0-41ff-959a-82bfae11b3a9", :type "Concert", :score 100, :name "Mats/Morgan at L'Austrasique", :life-span {:begin "2005-05-11", :end "2005-05-11"}, :relations [{:type "support act", :type-id "492a850e-97eb-306a-a85e-4b6d98527796", :direction "backward", :artist {:id "bc4e41d2-da66-415b-a57f-8f76dbed1729", :name "Jacques Tellitocci", :sort-name "Tellitocci, Jacques"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "90b0a86c-b692-478b-8eff-457121c0b870", :name "Mats/Morgan Band", :sort-name "Mats/Morgan Band"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "5dc331d4-efdb-4968-b18b-4b824a56bb2c", :name "L'Austrasique"}}]}
-    {:id "10fbfb6e-a6e0-4390-9d70-35e3e14c2020", :type "Concert", :score 100, :name "1972‐02‐05: The Back Door, Richmond, VA, USA", :disambiguation "The Bruce Springsteen Band", :life-span {:begin "1972-02-05", :end "1972-02-05"}, :relations [{:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "70248960-cb53-4ea4-943a-edb18f7d336f", :name "Bruce Springsteen", :sort-name "Springsteen, Bruce"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "1607e961-c4a7-4602-ac22-d0d87833eee3", :name "The Bruce Springsteen Band", :sort-name "Bruce Springsteen Band, The"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "6232a780-e557-4aa3-b5a2-c76bf572433f", :name "The Back Door"}}]}
-    {:id "b1f81805-88ef-48e1-9f9d-19684e702b4a", :type "Concert", :score 100, :name "A Head Full of Dreams Tour: La Plata", :disambiguation "night 1", :life-span {:begin "2016-03-31", :end "2016-03-31"}, :relations [{:type "support act", :type-id "492a850e-97eb-306a-a85e-4b6d98527796", :direction "backward", :artist {:id "680466d6-f05b-44f6-858d-625d1b5087f6", :name "Lianne La Havas", :sort-name "La Havas, Lianne"}} {:type "main performer", :type-id "936c7c95-3156-3889-a062-8a0cd57f8946", :direction "backward", :artist {:id "cc197bad-dc9c-440d-a5b5-d52ba2e14234", :name "Coldplay", :sort-name "Coldplay"}} {:type "held at", :type-id "e2c6f697-07dc-38b1-be0b-83d740165532", :direction "backward", :place {:id "6cec7a8f-12ca-4754-b861-fd6293110506", :name "Estadio Ciudad de La Plata"}}]}]])
+  [[{:id        "9a624d46-8cca-43bf-a58a-f8f21a2f98d8"
+     :type      "Concert"
+     :score     100
+     :name      "Alice Cooper at Grand Casino Hinckley Events & Convention Center"
+     :life-span {:begin "2017-06-08" :end "2017-06-08"}
+     :time      "20:00:00"
+     :relations [{:type "support act" :type-id "492a850e-97eb-306a-a85e-4b6d98527796" :direction "backward" :artist {:id "bd6b6464-0cf5-48d9-8b7f-52d88d4e87f0" :name "Chris Hawkey" :sort-name "Chris Hawkey"}}
+                 {:type      "main performer"
+                  :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                  :direction "backward"
+                  :artist    {:id             "ee58c59f-8e7f-4430-b8ca-236c4d3745ae"
+                              :name           "Alice Cooper"
+                              :sort-name      "Cooper, Alice"
+                              :disambiguation "the musician born Vincent Damon Furnier, changed his name legally to Alice Cooper in 1974"}}
+                 {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "8cfeea3a-132e-47f0-aaf5-d7f908f02f86" :name "Grand Casino Hinckley Amphitheater"}}]}
+    {:id        "a824bfa5-ed32-4b2a-82c4-8c9045d311b1"
+     :type      "Concert"
+     :score     100
+     :name      "Lost In The Manor - Old Queen's Head, Angel, London"
+     :life-span {:begin "2016-09-18" :end "2016-09-18"}
+     :time      "18:30:00"
+     :relations [{:type "held in" :type-id "542f8484-8bc7-3ce5-a022-747850b2b928" :direction "backward" :area {:id "f03d09b3-39dc-4083-afd6-159e3f0d462f" :name "London"}}]}
+    {:id        "5e98db6f-6132-4190-881c-acdf2ea94b59"
+     :type      "Concert"
+     :score     100
+     :name      "Queensrÿche at 日本青年館"
+     :life-span {:begin "1984-08-03" :end "1984-08-03"}
+     :relations [{:type "main performer" :type-id "936c7c95-3156-3889-a062-8a0cd57f8946" :direction "backward" :artist {:id "deeea939-7f89-4762-b09f-79269cd70d3b" :name "Queensrÿche" :sort-name "Queensrÿche"}}
+                 {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "4f21f35e-6d44-493a-93a2-94f1ac712c14" :name "日本青年館"}}]}
+    {:id             "a91fac23-3d87-4bdb-a89e-abcccea8c200"
+     :type           "Concert"
+     :score          100
+     :name           "1971‐11‐12: Student Prince, Asbury Park, NJ, USA"
+     :disambiguation "The Bruce Springsteen Band"
+     :life-span      {:begin "1971-11-12" :end "1971-11-13"}
+     :time           "21:30:00"
+     :relations      [{:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "70248960-cb53-4ea4-943a-edb18f7d336f" :name "Bruce Springsteen" :sort-name "Springsteen, Bruce"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "1607e961-c4a7-4602-ac22-d0d87833eee3" :name "The Bruce Springsteen Band" :sort-name "Bruce Springsteen Band, The"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6" :name "Student Prince"}}]}
+    {:id             "be5782a4-1bfe-4d03-8fd1-39e54b77bb80"
+     :type           "Concert"
+     :score          100
+     :name           "1971‐11‐21: Student Prince, Asbury Park, NJ, USA"
+     :disambiguation "The Bruce Springsteen Band"
+     :life-span      {:begin "1971-11-21" :end "1971-11-22"}
+     :time           "21:30:00"
+     :relations      [{:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "70248960-cb53-4ea4-943a-edb18f7d336f" :name "Bruce Springsteen" :sort-name "Springsteen, Bruce"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "1607e961-c4a7-4602-ac22-d0d87833eee3" :name "The Bruce Springsteen Band" :sort-name "Bruce Springsteen Band, The"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6" :name "Student Prince"}}]}]
+   [{:id             "69f7153a-2fff-425a-9b00-e02f14b54f2b"
+     :type           "Concert"
+     :score          100
+     :name           "1971‐11‐23: New Plaza Theater, Linden, NJ, USA"
+     :disambiguation "jam session"
+     :life-span      {:begin "1971-11-23" :end "1971-11-23"}
+     :relations      [{:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "23ab1c9b-5295-404d-9143-80e06b93341e" :name "Psychotic Blues Band" :sort-name "Band, Psychotic Blues" :disambiguation "New Jersey"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "051f7534-cad4-4f7f-a5ef-7403b1fcee02" :name "Tumbleweed" :sort-name "Tumbleweed" :disambiguation "New Jersey"}}
+                      {:type "main performer" :type-id "936c7c95-3156-3889-a062-8a0cd57f8946" :direction "backward" :artist {:id "5ba1e8d6-7c62-477e-bf01-10ef3048eb68" :name "Pat Karwin" :sort-name "Karwin, Pat"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "4cda092b-95fb-45fc-ae29-5830c82bf036" :name "Taylors Mills Road" :sort-name "Road, Taylors Mills"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "41a8f637-21f3-408c-a1d8-972bea1523e2" :name "The Rich Baron Band" :sort-name "Rich Baron Band, The"}}
+                      {:type      "guest performer"
+                       :type-id   "292df906-98a6-307e-86e8-df01a579a321"
+                       :direction "backward"
+                       :artist    {:id "70248960-cb53-4ea4-943a-edb18f7d336f" :name "Bruce Springsteen" :sort-name "Springsteen, Bruce"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "cfe59d21-9ede-45ef-b6e4-21b6fa3e433b" :name "New Plaza Theater"}}]}
+    {:id             "c7c94544-5693-4569-8927-53f03b7c1be3"
+     :type           "Concert"
+     :score          100
+     :name           "1971‐11‐28: Student Prince, Asbury Park, NJ, USA"
+     :disambiguation "The Bruce Springsteen Band"
+     :life-span      {:begin "1971-11-28" :end "1971-11-29"}
+     :time           "21:30:00"
+     :relations      [{:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "70248960-cb53-4ea4-943a-edb18f7d336f" :name "Bruce Springsteen" :sort-name "Springsteen, Bruce"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "1607e961-c4a7-4602-ac22-d0d87833eee3" :name "The Bruce Springsteen Band" :sort-name "Bruce Springsteen Band, The"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "7c0e5bb2-9a14-4732-a87e-796c1acba1c6" :name "Student Prince"}}]}
+    {:id        "807f3f14-f3b0-41ff-959a-82bfae11b3a9"
+     :type      "Concert"
+     :score     100
+     :name      "Mats/Morgan at L'Austrasique"
+     :life-span {:begin "2005-05-11" :end "2005-05-11"}
+     :relations [{:type      "support act"
+                  :type-id   "492a850e-97eb-306a-a85e-4b6d98527796"
+                  :direction "backward"
+                  :artist    {:id "bc4e41d2-da66-415b-a57f-8f76dbed1729" :name "Jacques Tellitocci" :sort-name "Tellitocci, Jacques"}}
+                 {:type "main performer" :type-id "936c7c95-3156-3889-a062-8a0cd57f8946" :direction "backward" :artist {:id "90b0a86c-b692-478b-8eff-457121c0b870" :name "Mats/Morgan Band" :sort-name "Mats/Morgan Band"}}
+                 {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "5dc331d4-efdb-4968-b18b-4b824a56bb2c" :name "L'Austrasique"}}]}
+    {:id             "10fbfb6e-a6e0-4390-9d70-35e3e14c2020"
+     :type           "Concert"
+     :score          100
+     :name           "1972‐02‐05: The Back Door, Richmond, VA, USA"
+     :disambiguation "The Bruce Springsteen Band"
+     :life-span      {:begin "1972-02-05" :end "1972-02-05"}
+     :relations      [{:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "70248960-cb53-4ea4-943a-edb18f7d336f" :name "Bruce Springsteen" :sort-name "Springsteen, Bruce"}}
+                      {:type      "main performer"
+                       :type-id   "936c7c95-3156-3889-a062-8a0cd57f8946"
+                       :direction "backward"
+                       :artist    {:id "1607e961-c4a7-4602-ac22-d0d87833eee3" :name "The Bruce Springsteen Band" :sort-name "Bruce Springsteen Band, The"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "6232a780-e557-4aa3-b5a2-c76bf572433f" :name "The Back Door"}}]}
+    {:id             "b1f81805-88ef-48e1-9f9d-19684e702b4a"
+     :type           "Concert"
+     :score          100
+     :name           "A Head Full of Dreams Tour: La Plata"
+     :disambiguation "night 1"
+     :life-span      {:begin "2016-03-31" :end "2016-03-31"}
+     :relations      [{:type "support act" :type-id "492a850e-97eb-306a-a85e-4b6d98527796" :direction "backward" :artist {:id "680466d6-f05b-44f6-858d-625d1b5087f6" :name "Lianne La Havas" :sort-name "La Havas, Lianne"}}
+                      {:type "main performer" :type-id "936c7c95-3156-3889-a062-8a0cd57f8946" :direction "backward" :artist {:id "cc197bad-dc9c-440d-a5b5-d52ba2e14234" :name "Coldplay" :sort-name "Coldplay"}}
+                      {:type "held at" :type-id "e2c6f697-07dc-38b1-be0b-83d740165532" :direction "backward" :place {:id "6cec7a8f-12ca-4754-b861-fd6293110506" :name "Estadio Ciudad de La Plata"}}]}]])
 
 
 (deftest enrich-action-test
@@ -56,54 +186,55 @@
       (is (= (map :type actual) [:mapper :collet.actions.http/request :fold]))))
 
   (testing "enrich action in the context of task execution"
-    (let [task-spec {:name     :enrich-test
-                     :actions  [{:type      :enrich
-                                 :name      :enrich-collection
-                                 :target    [:config :collection]
-                                 :action    :custom
-                                 :selectors {'id   [:$enrich/item :id]
-                                             'data [:config :data]}
-                                 :params    ['data 'id]
-                                 :fn        (fn [data id]
-                                              (get data id))}]
-                     :iterator {:next [:true? [:$enrich/has-next-item]]}}
+    (let [task-spec         {:name     :enrich-test
+                             :actions  [{:type      :enrich
+                                         :name      :enrich-collection
+                                         :target    [:config :collection]
+                                         :action    :custom
+                                         :selectors {'id   [:$enrich/item :id]
+                                                     'data [:config :data]}
+                                         :params    ['data 'id]
+                                         :fn        (fn [data id]
+                                                      (get data id))}]
+                             :iterator {:next [:true? [:$enrich/has-next-item]]}}
           {:keys [task-fn]} (collet/compile-task (utils/eval-ctx) task-spec)
-          result    (-> (task-fn {:config {:collection [{:id 1} {:id 2} {:id 3}]
-                                           :data       {1 {:name "one"}
-                                                        2 {:name "two"}
-                                                        3 {:name "three"}}}
-                                  :state  {}})
-                        (vec))]
+          result            (-> (task-fn {:config {:collection [{:id 1} {:id 2} {:id 3}]
+                                                   :data       {1 {:name "one"}
+                                                                2 {:name "two"}
+                                                                3 {:name "three"}}}
+                                          :state  {}})
+                                (vec))]
       (is (= 3 (count result)))
-      (is (= [{:id 1, :name "one"} {:id 2, :name "two"} {:id 3, :name "three"}]
+      (is (= [{:id 1 :name "one"} {:id 2 :name "two"} {:id 3 :name "three"}]
              (last result))))))
 
 
 (deftest enrich-data-pipeline-test
   (testing "enrich action in the context of pipeline execution"
-    (let [pipeline-spec {:name  :city-events-with-artists
-                         :deps  {:coordinates '[[io.velio/collet-actions "0.2.8"]]}
-                         :tasks [{:name       :events-with-artists
-                                  :keep-state true
-                                  :setup      [{:type      :slicer
-                                                :name      :city-events-list
-                                                :selectors {'events [:config :area-events]}
-                                                :params    {:sequence 'events
-                                                            :cat?     true
-                                                            :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
-                                  :actions    [{:type      :enrich
-                                                :name      :enrich-artist-details
-                                                :target    [:state :city-events-list]
-                                                :when      [:not-nil? [:$enrich/item :artist :id]]
-                                                :action    :collet.actions.http/request
-                                                :selectors {'artist-id [:$enrich/item :artist :id]}
-                                                :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
-                                                            :accept       :json
-                                                            :as           :json
-                                                            :query-params {:inc "ratings"}}
-                                                :return    [:body]
-                                                :fold-in   [:artist]}]
-                                  :iterator   {:next [:true? [:$enrich/has-next-item]]}}]}
+    (let [pipeline-spec {:name      :city-events-with-artists
+                         :use-arrow false
+                         :deps      {:coordinates '[[io.velio/collet-actions "0.2.8"]]}
+                         :tasks     [{:name       :events-with-artists
+                                      :keep-state true
+                                      :setup      [{:type      :slicer
+                                                    :name      :city-events-list
+                                                    :selectors {'events [:config :area-events]}
+                                                    :params    {:sequence 'events
+                                                                :cat?     true
+                                                                :apply    [[:flatten {:by {:artist [:relations [:$/cat [:$/cond [:not-nil? :artist]] :artist]]}}]]}}]
+                                      :actions    [{:type      :enrich
+                                                    :name      :enrich-artist-details
+                                                    :target    [:state :city-events-list]
+                                                    :when      [:not-nil? [:$enrich/item :artist :id]]
+                                                    :action    :collet.actions.http/request
+                                                    :selectors {'artist-id [:$enrich/item :artist :id]}
+                                                    :params    {:url          [(http/musicbrainz-url "/artist/%s") 'artist-id]
+                                                                :accept       :json
+                                                                :as           :json
+                                                                :query-params {:inc "ratings"}}
+                                                    :return    [:body]
+                                                    :fold-in   [:artist]}]
+                                      :iterator   {:next [:true? [:$enrich/has-next-item]]}}]}
           pipeline      (run-durable-pipeline pipeline-spec
                                               {:area-events test-events-data})]
 

--- a/collet-core/test/collet/arrow_test.clj
+++ b/collet-core/test/collet/arrow_test.clj
@@ -2,19 +2,26 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
+   [collet.arrow :as sut]
    [collet.test-fixtures :as tf]
-   [tech.v3.dataset :as ds]
-   [collet.arrow :as sut])
+   [tech.v3.dataset :as ds])
   (:import
-   [java.time LocalDate LocalDateTime LocalTime Instant Duration]
-   [org.apache.arrow.vector.types.pojo ArrowType$Int ArrowType$Timestamp Schema]
-   [org.apache.arrow.vector.types TimeUnit]
-   [org.apache.arrow.vector VectorSchemaRoot]
-   [org.apache.arrow.memory RootAllocator]
-   [org.apache.arrow.vector.complex ListVector]))
+    (clojure.lang ExceptionInfo)
+    [java.io File]
+    [java.math BigDecimal BigInteger]
+    [java.time LocalDate LocalDateTime LocalTime Instant Duration]
+    [java.util Date]
+    [org.apache.arrow.vector.types.pojo ArrowType$Int ArrowType$Timestamp Schema]
+    [org.apache.arrow.vector.types TimeUnit]
+    [org.apache.arrow.vector VectorSchemaRoot]
+    [org.apache.arrow.memory RootAllocator]
+    [org.apache.arrow.vector.complex ListVector]))
 
 
 (use-fixtures :once (tf/instrument! 'collet.arrow))
+
+
+(declare with-arrow-file)
 
 
 (deftest test-ds->columns
@@ -32,10 +39,15 @@
   (let [data    [{:name "Alice" :age 30 :scores [95 85 75]}
                  {:name "Bob" :age 25 :scores [88 78 68]}]
         columns (sut/get-columns data)]
-    (is (= (count columns) 3))
-    (is (= (first columns) [:name "name" :string]))
-    (is (= (second columns) [:age "age" :int64]))
-    (is (= (nth columns 2) [:scores "scores" [:list :int64]]))))
+    (is (= {:version 1
+            :fields  [{:key :name :name "name" :type :string :nullable? true}
+                      {:key :age :name "age" :type :int64 :nullable? true}
+                      {:key       :scores
+                       :name      "scores"
+                       :type      :list
+                       :nullable? true
+                       :element   {:type :int64 :nullable? true}}]}
+           columns))))
 
 
 (deftest test-create-field
@@ -144,10 +156,12 @@
   (let [columns (sut/get-columns [{:id 1 :name "Alice" :score (float 95.5) :obj [1 2 3]}
                                   {:id 2 :name "Bob" :score (float 85.0) :obj [3 4 5]}])]
     (with-open [writer (sut/make-writer "tmp/test.arrow" columns)]
-      (sut/write writer [{:id 1 :name "Alice" :score (float 95.5) :obj [1 2 3]}
-                         {:id 2 :name "Bob" :score (float 85.0) :obj [3 4 5]}])
-      (sut/write writer [{:id 3 :name "Charlie" :score (float 77.3)}
-                         {:id 4 :name "Diana" :score (float 89.9) :obj [6 7 8]}]))
+      (sut/write writer
+                 [{:id 1 :name "Alice" :score (float 95.5) :obj [1 2 3]}
+                  {:id 2 :name "Bob" :score (float 85.0) :obj [3 4 5]}])
+      (sut/write writer
+                 [{:id 3 :name "Charlie" :score (float 77.3)}
+                  {:id 4 :name "Diana" :score (float 89.9) :obj [6 7 8]}]))
     (let [dataset-seq (sut/read-dataset "tmp/test.arrow" columns)]
       (is (= 2 (ds/row-count (first dataset-seq))))
       (is (= [:id :name :score :obj] (ds/column-names (first dataset-seq))))
@@ -168,10 +182,12 @@
   (let [columns (sut/get-columns [{:id 1 :name "Alice" :score (float 95.5) :obj ["1" "2" "3"]}
                                   {:id 2 :name "Bob" :score (float 85.0) :obj ["3" "4" "5"]}])]
     (with-open [writer (sut/make-writer "tmp/test.arrow" columns)]
-      (sut/write writer [{:id 1 :name "Alice" :score (float 95.5) :obj ["item1" "item2" "item3"]}
-                         {:id 2 :name "Bob" :score (float 85.0) :obj ["item3" "item4" "item5"]}])
-      (sut/write writer [{:id 3 :name "Charlie" :score (float 77.3)}
-                         {:id 4 :name "Diana" :score (float 89.9) :obj ["item6" "item7" "item8"]}]))
+      (sut/write writer
+                 [{:id 1 :name "Alice" :score (float 95.5) :obj ["item1" "item2" "item3"]}
+                  {:id 2 :name "Bob" :score (float 85.0) :obj ["item3" "item4" "item5"]}])
+      (sut/write writer
+                 [{:id 3 :name "Charlie" :score (float 77.3)}
+                  {:id 4 :name "Diana" :score (float 89.9) :obj ["item6" "item7" "item8"]}]))
     (let [dataset-seq (sut/read-dataset "tmp/test.arrow" columns)]
       (is (= 2 (ds/row-count (first dataset-seq))))
       (is (= 2 (ds/row-count (second dataset-seq))))
@@ -184,38 +200,39 @@
 
 
 (deftest test-read-dataset-all-types
-  (let [uuid       (random-uuid)
+  (let [uuid (random-uuid)
         local-date (LocalDate/of 2025 1 2)
         local-time (LocalTime/of 12 34 56 789000000)
-        instant    (Instant/ofEpochSecond 123 456000000)
-        data       [{:instant            instant
-                     :epoch-milliseconds instant
-                     :epoch-microseconds instant
-                     :epoch-nanoseconds  instant
-                     :boolean            true
-                     :uint8              255
-                     :int8               -128
-                     :uint16             65535
-                     :int16              -32768
-                     :uint32             4294967295
-                     :int32              -2147483648
-                     :uint64             184467440737095516
-                     :int64              -922337203685477580
-                     :float32            3.14
-                     :float64            3.141592653589793
-                     :epoch-days         local-date
-                     :local-date         local-date
-                     :local-time         local-time
-                     :time-nanoseconds   local-time
-                     :time-microseconds  local-time
-                     :time-milliseconds  local-time
-                     :time-seconds       local-time
-                     :duration           (Duration/ofSeconds 123 456000000)
-                     :string             "test"
-                     :uuid               uuid
-                     :text               "text"
-                     :encoded-text       "encoded"}]
-        columns    (sut/get-columns data)]
+        instant (Instant/ofEpochSecond 123 456000000)
+        data
+        [{:instant            instant
+          :epoch-milliseconds instant
+          :epoch-microseconds instant
+          :epoch-nanoseconds  instant
+          :boolean            true
+          :uint8              255
+          :int8               -128
+          :uint16             65535
+          :int16              -32768
+          :uint32             4294967295
+          :int32              -2147483648
+          :uint64             184467440737095516
+          :int64              -922337203685477580
+          :float32            3.14
+          :float64            3.141592653589793
+          :epoch-days         local-date
+          :local-date         local-date
+          :local-time         local-time
+          :time-nanoseconds   local-time
+          :time-microseconds  local-time
+          :time-milliseconds  local-time
+          :time-seconds       local-time
+          :duration           (Duration/ofSeconds 123 456000000)
+          :string             "test"
+          :uuid               uuid
+          :text               "text"
+          :encoded-text       "encoded"}]
+        columns (sut/get-columns data)]
     (with-open [writer (sut/make-writer "tmp/test-all-types.arrow" columns)]
       (sut/write writer data))
     (let [dataset-seq (sut/read-dataset "tmp/test-all-types.arrow" columns)
@@ -253,5 +270,550 @@
       (is (= (record :instant) instant))
       (is (= (record :epoch-milliseconds) instant))
       (is (= (record :epoch-microseconds) instant))
-      (is (= (record :epoch-nanoseconds) instant))))
+      (is (= (record :epoch-nanoseconds) instant))
+      (with-arrow-file
+       (fn [copy-file]
+         (with-open [writer (sut/make-writer copy-file columns)]
+           (sut/write writer dataset))
+         (let [roundtrip (-> (sut/read-dataset copy-file columns)
+                             first
+                             ds/rows
+                             first
+                             (sut/prep-record columns))]
+           (is (= (:duration (first data)) (:duration roundtrip)))
+           (is (= (:local-date (first data)) (:local-date roundtrip)))
+           (is (= (:local-time (first data)) (:local-time roundtrip)))
+           (is (= (:local-date-time (first data)) (:local-date-time roundtrip)))
+           (is (= (:instant (first data)) (:instant roundtrip))))))))
   (io/delete-file "tmp/test-all-types.arrow"))
+
+
+(def nested-schema
+  (sut/normalize-schema
+   {:version 1
+    :fields  [{:key :id :name "id" :type :int64}
+              {:key    :address
+               :name   "address"
+               :type   :struct
+               :fields [{:key :line :name "line" :type :string}
+                        {:key :city :name "city" :type :string}
+                        {:key :zip :name "zip" :type :int32 :nullable? false}]}
+              {:key :attributes :name "attributes" :type :map}
+              {:key     :tags
+               :name    "tags"
+               :type    :list
+               :element {:type :string}}
+              {:key     :events
+               :name    "events"
+               :type    :list
+               :element {:type   :struct
+                         :fields [{:key :kind :name "kind" :type :string}
+                                  {:key :score :name "score" :type :int32}]}}
+              {:key     :embedding
+               :name    "embedding"
+               :type    :fixed-size-list
+               :size    3
+               :element {:type :float32 :nullable? false}}
+              {:key       :amount
+               :name      "amount"
+               :type      :decimal
+               :bit-width 128
+               :precision 10
+               :scale     2}
+              {:key          :big-id
+               :name         "big_id"
+               :type         :decimal
+               :bit-width    256
+               :precision    76
+               :scale        0
+               :logical-type :big-integer}]}))
+
+
+(defn with-arrow-file
+  [f]
+  (let [file (File/createTempFile "collet-arrow-test" ".arrow")]
+    (try
+      (f file)
+      (finally
+       (.delete file)))))
+
+
+(defn write-error
+  [schema rows]
+  (with-arrow-file
+   (fn [file]
+     (try
+       (with-open [writer (sut/make-writer file schema)]
+         (sut/write writer rows))
+       nil
+       (catch ExceptionInfo error
+         error)))))
+
+
+(defn normalization-error
+  [normalizer]
+  (try
+    (normalizer)
+    (catch ExceptionInfo error
+      error)))
+
+
+(deftest malli-normalization-defaults-test
+  (doseq [{:keys [description input expected]}
+          [{:description "keyword descriptor"
+            :input       :string
+            :expected    {:type :string :nullable? true}}
+           {:description "explicit false nullability"
+            :input       {:type :string :nullable? false}
+            :expected    {:type :string :nullable? false}}
+           {:description "explicit nil nullability"
+            :input       {:type :string :nullable? nil}
+            :expected    {:type :string :nullable? false}}
+           {:description "truthy nullability"
+            :input       {:type :string :nullable? "yes"}
+            :expected    {:type :string :nullable? true}}
+           {:description "recursive list of struct"
+            :input       {:type    :list
+                          :element {:type   :struct
+                                    :fields [{:key :score :name "score" :type :int32}]}}
+            :expected    {:type      :list
+                          :nullable? true
+                          :element   {:type      :struct
+                                      :nullable? true
+                                      :fields    [{:key :score :name "score" :type :int32 :nullable? true}]}}}]]
+    (testing description
+      (is (= expected (sut/normalize-descriptor input)))))
+  (doseq [{:keys [description input expected]}
+          [{:description "canonical schema"
+            :input       {:fields [{:key :id :name "id" :type :string}]}
+            :expected    {:version 1
+                          :fields  [{:key :id :name "id" :type :string :nullable? true}]}}
+           {:description "legacy column triplet"
+            :input       [[:id "id" :string]]
+            :expected    {:version 1
+                          :fields  [{:key :id :name "id" :type :string :nullable? true}]}}]]
+    (testing description
+      (is (= expected (sut/normalize-schema input))))))
+
+
+(deftest malli-normalization-test
+  (let [descriptor
+        (sut/normalize-descriptor
+         {:type       :instant
+          :nullable?  nil
+          :timezone   false
+          :custom-tag {:keep true}})
+        map-descriptor (sut/normalize-descriptor {:type :map})
+        schema
+        (sut/normalize-schema
+         {:version nil
+          :ignored :drop
+          :fields  [{:key       :events
+                     :name      "events"
+                     :type      :list
+                     :custom    :keep
+                     :nullable? "false"
+                     :element   {:type   :struct
+                                 :fields [{:key :score :name "score" :type :int32}]}}
+                    {:key  :created-at
+                     :name "created_at"
+                     :type :instant}]})]
+    (is (= {:type       :instant
+            :nullable?  false
+            :timezone   "UTC"
+            :custom-tag {:keep true}}
+           descriptor))
+    (is (= {:type       :map
+            :nullable?  true
+            :key-type   {:type :string :nullable? false}
+            :value-type {:type :string :nullable? true}}
+           map-descriptor))
+    (is (= {:version 1
+            :fields  [{:key       :events
+                       :name      "events"
+                       :type      :list
+                       :custom    :keep
+                       :nullable? true
+                       :element   {:type      :struct
+                                   :fields    [{:key :score :name "score" :type :int32 :nullable? true}]
+                                   :nullable? true}}
+                      {:key       :created-at
+                       :name      "created_at"
+                       :type      :instant
+                       :nullable? true
+                       :timezone  "UTC"}]}
+           schema))
+    (is (= [:events :created-at] (mapv :key (:fields schema))))
+    (is (not (contains? schema :ignored))))
+  (is (= {:version 1
+          :fields  [{:key       :created-at
+                     :name      "created_at"
+                     :type      :instant
+                     :nullable? true
+                     :timezone  "UTC"}
+                    {:key       :scores
+                     :name      "scores"
+                     :type      :list
+                     :nullable? true
+                     :element   {:type :int32 :nullable? true}}]}
+         (sut/normalize-schema
+          [[:created-at "created_at" [:zoned :instant]]
+           [:scores "scores" [:list :int32]]]))))
+
+
+(deftest malli-schema-validation-errors-test
+  (doseq [{:keys [reason message normalize]}
+          [{:reason    :invalid-descriptor
+            :message   "Arrow descriptor must be a keyword or map."
+            :normalize #(sut/normalize-descriptor [])}
+           {:reason    :unsupported-type
+            :message   "Unsupported Arrow type :wat."
+            :normalize #(sut/normalize-descriptor {:type :wat})}
+           {:reason    :invalid-struct
+            :message   "Arrow Struct requires an ordered :fields vector."
+            :normalize #(sut/normalize-descriptor {:type :struct})}
+           {:reason    :invalid-map-key
+            :message   "Arrow Map keys must be non-null UTF-8 strings."
+            :normalize #(sut/normalize-descriptor
+                         {:type :map :key-type {:type :string}})}
+           {:reason    :invalid-map-value
+            :message   "Arrow Map values must be nullable UTF-8 strings."
+            :normalize #(sut/normalize-descriptor
+                         {:type :map :value-type {:type :string :nullable? false}})}
+           {:reason    :missing-list-element
+            :message   "Arrow List requires :element."
+            :normalize #(sut/normalize-descriptor {:type :list})}
+           {:reason    :invalid-fixed-size
+            :message   "Arrow fixed-size list requires a positive :size."
+            :normalize #(sut/normalize-descriptor
+                         {:type :fixed-size-list :size 0 :element :float32})}
+           {:reason    :invalid-fixed-size
+            :message   "Arrow fixed-size list :size must not exceed 2147483647."
+            :normalize #(sut/normalize-descriptor
+                         {:type    :fixed-size-list
+                          :size    2147483648
+                          :element :float32})}
+           {:reason    :invalid-fixed-size-element
+            :message   "Arrow fixed-size lists currently require Float32 elements."
+            :normalize #(sut/normalize-descriptor
+                         {:type :fixed-size-list :size 1 :element :int32})}
+           {:reason    :invalid-timezone
+            :message   "Arrow timezone must be a string."
+            :normalize #(sut/normalize-descriptor
+                         {:type :instant :timezone 42})}
+           {:reason    :invalid-decimal-width
+            :message   "Arrow decimal :bit-width must be 128 or 256."
+            :normalize #(sut/normalize-descriptor
+                         {:type :decimal :bit-width 1 :precision 1 :scale 0})}
+           {:reason    :invalid-decimal-precision
+            :message   "Arrow decimal precision must be between 1 and 38."
+            :normalize #(sut/normalize-descriptor
+                         {:type :decimal :bit-width 128 :precision 39 :scale 0})}
+           {:reason    :invalid-decimal-scale
+            :message   "Arrow decimal scale must be between zero and its precision."
+            :normalize #(sut/normalize-descriptor
+                         {:type :decimal :bit-width 128 :precision 1 :scale 2})}
+           {:reason    :invalid-decimal-logical-type
+            :message   "Arrow decimal logical type must be :big-integer when present."
+            :normalize #(sut/normalize-descriptor
+                         {:type :decimal :bit-width 128 :precision 1 :scale 0 :logical-type :wat})}
+           {:reason    :invalid-big-integer-scale
+            :message   "Logical BigInteger decimals require scale zero."
+            :normalize #(sut/normalize-descriptor
+                         {:type :decimal :bit-width 128 :precision 1 :scale 1 :logical-type :big-integer})}
+           {:reason    :invalid-field-key
+            :message   "Arrow field :key must be a keyword or string."
+            :normalize #(sut/normalize-field {:type :string :name "field"})}
+           {:reason    :invalid-field-name
+            :message   "Arrow field :name must be a string."
+            :normalize #(sut/normalize-field {:type :string :key :field})}
+           {:reason    :invalid-schema
+            :message   "Arrow schema must be a map or legacy column vector."
+            :normalize #(sut/normalize-schema nil)}
+           {:reason    :unsupported-schema-version
+            :message   "Unsupported Arrow schema version 2."
+            :normalize #(sut/normalize-schema {:version 2 :fields []})}
+           {:reason    :invalid-fields
+            :message   "Arrow schema requires an ordered :fields vector."
+            :normalize #(sut/normalize-schema {:version 1})}
+           {:reason    :invalid-legacy-column
+            :message   "Legacy Arrow columns must be [key physical-name type] triplets."
+            :normalize #(sut/normalize-schema [[:id "id"]])}
+           {:reason    :invalid-legacy-column
+            :message   "Arrow columns must use a known legacy type or descriptor map."
+            :normalize #(sut/normalize-schema [[:id "id" 42]])}
+           {:reason    :duplicate-field-name
+            :message   "Arrow field names must be unique."
+            :normalize #(sut/normalize-schema
+                         {:version 1
+                          :fields  [{:key :first :name "name" :type :string}
+                                    {:key :second :name "name" :type :string}]})}
+           {:reason    :duplicate-field-key
+            :message   "Arrow field keys must be unique."
+            :normalize #(sut/normalize-schema
+                         {:version 1
+                          :fields  [{:key :name :name "first" :type :string}
+                                    {:key :name :name "second" :type :string}]})}
+           {:reason    :duplicate-field-key
+            :message   "Arrow field keys must be unique."
+            :normalize #(sut/normalize-schema
+                         {:version 1
+                          :fields  [{:key    :profile
+                                     :name   "profile"
+                                     :type   :struct
+                                     :fields [{:key :name :name "name" :type :string}
+                                              {:key :name :name "alias" :type :string}]}]})}]]
+    (testing (str reason " preserves its error contract")
+      (let [error (normalization-error normalize)
+            data  (ex-data error)]
+        (is (instance? ExceptionInfo error))
+        (is (= message (ex-message error)))
+        (is (= :collet.error/arrow-invalid-schema (:collet.error/type data)))
+        (is (= reason (:reason data)))
+        (is (not-any? #(contains? data %) [:value :schema :errors :row :batch])))))
+  (let [error (normalization-error
+               #(sut/normalize-descriptor
+                 {:type         :decimal
+                  :bit-width    1
+                  :precision    0
+                  :scale        -1
+                  :logical-type :wat}))]
+    (is (= :invalid-decimal-width (:reason (ex-data error)))))
+  (doseq [{:keys [description normalize reason message]}
+          [{:description "schema version precedes an invalid field"
+            :normalize   #(sut/normalize-schema
+                           {:version 2 :fields [{:type :string}]})
+            :reason      :unsupported-schema-version
+            :message     "Unsupported Arrow schema version 2."}
+           {:description "an earlier legacy field precedes a later malformed triplet"
+            :normalize   #(sut/normalize-schema [[:id "id" :wat] [:broken]])
+            :reason      :unsupported-type
+            :message     "Unsupported Arrow type :wat."}]]
+    (testing description
+      (let [error (normalization-error normalize)]
+        (is (= reason (:reason (ex-data error))))
+        (is (= message (ex-message error)))))))
+
+
+(deftest nested-roundtrip-and-null-semantics-test
+  (let [first-batch  [{:id         1
+                       :address    {:line "One" :city nil :zip 28001}
+                       :attributes {"source" "api" "missing" nil}
+                       :tags       ["new" nil]
+                       :events     [{:kind "created" :score 7} nil]
+                       :embedding  [1.0 2.0 3.0]
+                       :amount     (BigDecimal. "12.30")
+                       :big-id     (BigInteger. "18446744073709551616")}
+                      {:id         2
+                       :address    nil
+                       :attributes {}
+                       :tags       []
+                       :events     []
+                       :embedding  nil
+                       :amount     nil
+                       :big-id     nil}]
+        second-batch [{:id         3
+                       :address    {:line nil :city "Madrid" :zip 28002}
+                       :attributes nil
+                       :tags       nil
+                       :events     nil
+                       :embedding  [3.0 2.0 1.0]
+                       :amount     (BigDecimal. "0.00")
+                       :big-id     BigInteger/ZERO}]
+        expected     [{:id         1
+                       :address    {:line "One" :city nil :zip 28001}
+                       :attributes {"source" "api" "missing" nil}
+                       :tags       ["new" nil]
+                       :events     [{:kind "created" :score 7} nil]
+                       :embedding  [1.0 2.0 3.0]
+                       :amount     (BigDecimal. "12.30")
+                       :big-id     (BigInteger. "18446744073709551616")}
+                      {:id         2
+                       :address    nil
+                       :attributes {}
+                       :tags       []
+                       :events     []
+                       :embedding  nil
+                       :amount     nil
+                       :big-id     nil}
+                      {:id         3
+                       :address    {:line nil :city "Madrid" :zip 28002}
+                       :attributes nil
+                       :tags       nil
+                       :events     nil
+                       :embedding  [3.0 2.0 1.0]
+                       :amount     (BigDecimal. "0.00")
+                       :big-id     BigInteger/ZERO}]]
+    (with-arrow-file
+     (fn [file]
+       (with-open [writer (sut/make-writer file nested-schema)]
+         (sut/write writer first-batch)
+         (sut/write writer second-batch))
+       (let [datasets (sut/read-dataset file nested-schema)
+             rows     (mapv #(sut/prep-record % nested-schema)
+                            (mapcat ds/rows datasets))]
+         (is (= [2 1] (mapv ds/row-count datasets)))
+         (is (= nested-schema (:arrow-columns (meta datasets))))
+         (is (= expected rows)))))))
+
+
+(deftest nested-uuid-roundtrip-test
+  (let [id     (random-uuid)
+        schema (sut/normalize-schema
+                {:version 1
+                 :fields  [{:key    :profile
+                            :name   "profile"
+                            :type   :struct
+                            :fields [{:key :id :name "id" :type :uuid}]}
+                           {:key     :ids
+                            :name    "ids"
+                            :type    :list
+                            :element {:type :uuid}}]})]
+    (with-arrow-file
+     (fn [file]
+       (with-open [writer (sut/make-writer file schema)]
+         (sut/write writer [{:profile {:id id} :ids [id]}]))
+       (is (= {:profile {:id id} :ids [id]}
+              (-> (sut/read-dataset file schema)
+                  first
+                  ds/rows
+                  first
+                  (sut/prep-record schema))))))))
+
+
+(deftest missing-dataset-field-validation-test
+  (let [schema (sut/normalize-schema
+                {:version 1
+                 :fields  [{:key       :logical-id
+                            :name      "physical_id"
+                            :type      :int64
+                            :nullable? false}]})
+        error  (write-error schema (ds/->dataset [{:other 1}]))]
+    (is (= :collet.error/arrow-invalid-value
+           (:collet.error/type (ex-data error))))
+    (is (= :non-nullable (:reason (ex-data error))))
+    (is (= [0 :logical-id] (:path (ex-data error))))))
+
+
+(deftest explicit-schema-validation-test
+  (let [missing-child (write-error nested-schema [{:address {:line "One"}}])
+        extra-child (write-error nested-schema [{:address {:line "One" :zip 1 :extra true}}])
+        fixed-length (write-error nested-schema [{:embedding [1.0 2.0]}])
+        duplicate-child
+        (try
+          (sut/normalize-schema
+           {:version 1
+            :fields  [{:key    :profile
+                       :name   "profile"
+                       :type   :struct
+                       :fields [{:key :name :name "name" :type :string}
+                                {:key :alias :name "name" :type :string}]}]})
+          (catch ExceptionInfo error
+            error))
+        nested-score (write-error
+                      (sut/normalize-schema
+                       {:version 1
+                        :fields  [{:key     :events
+                                   :name    "events"
+                                   :type    :list
+                                   :element {:type   :struct
+                                             :fields [{:key       :score
+                                                       :name      "score"
+                                                       :type      :int32
+                                                       :nullable? false}]}}]})
+                      [{:events [{:score nil}]}])]
+    (is (= :non-nullable (:reason (ex-data missing-child))))
+    (is (= [0 :address :zip] (:path (ex-data missing-child))))
+    (is (= :unknown-struct-key (:reason (ex-data extra-child))))
+    (is (= :wrong-fixed-size (:reason (ex-data fixed-length))))
+    (is (= :duplicate-field-name (:reason (ex-data duplicate-child))))
+    (is (= [0 :events 0 :score] (:path (ex-data nested-score))))
+    (is (not (contains? (ex-data nested-score) :batch)))
+    (is (not (contains? (ex-data nested-score) :row)))))
+
+
+(deftest decimal-and-integer-boundary-test
+  (let [max-128 (BigDecimal. (apply str (repeat 38 "9")))
+        max-256 (BigDecimal. (apply str (repeat 76 "9")))
+        max-big (BigInteger. (apply str (repeat 76 "9")))
+        schema  (sut/normalize-schema
+                 {:version 1
+                  :fields  [{:key       :d128
+                             :name      "d128"
+                             :type      :decimal
+                             :bit-width 128
+                             :precision 38
+                             :scale     0}
+                            {:key       :d256
+                             :name      "d256"
+                             :type      :decimal
+                             :bit-width 256
+                             :precision 76
+                             :scale     0}
+                            {:key          :big
+                             :name         "big"
+                             :type         :decimal
+                             :bit-width    256
+                             :precision    76
+                             :scale        0
+                             :logical-type :big-integer}]})]
+    (with-arrow-file
+     (fn [file]
+       (with-open [writer (sut/make-writer file schema)]
+         (sut/write writer [{:d128 max-128 :d256 max-256 :big max-big}]))
+       (is (= {:d128 max-128 :d256 max-256 :big max-big}
+              (-> (sut/read-dataset file schema)
+                  first
+                  ds/rows
+                  first
+                  (sut/prep-record schema))))))
+    (let [rounding (write-error nested-schema [{:amount (BigDecimal. "1.234")}])
+          overflow (write-error
+                    (sut/normalize-schema
+                     {:version 1
+                      :fields  [{:key :value :name "value" :type :int8}]})
+                    [{:value 128}])]
+      (is (= :rounding-required (:reason (ex-data rounding))))
+      (is (= :integer-overflow (:reason (ex-data overflow)))))
+    (is (= :invalid-decimal-precision
+           (:reason (ex-data
+                     (try
+                       (sut/normalize-schema
+                        {:version 1
+                         :fields  [{:key       :bad
+                                    :name      "bad"
+                                    :type      :decimal
+                                    :bit-width 128
+                                    :precision 39
+                                    :scale     0}]})
+                       (catch ExceptionInfo error
+                         error))))))))
+
+
+(deftest inference-and-legacy-date-test
+  (is (= :collet.error/arrow-schema-required
+         (:collet.error/type
+          (ex-data
+           (try
+             (sut/infer-schema! [{:value {:name "Ada"}}])
+             (catch ExceptionInfo error
+               error))))))
+  (is (nil? (sut/get-columns [{:value {:name "Ada"}}])))
+  (is (= :collet.error/arrow-schema-required
+         (:collet.error/type
+          (ex-data
+           (try
+             (sut/infer-schema! [{:values []}])
+             (catch ExceptionInfo error
+               error))))))
+  (let [error (write-error
+               (sut/normalize-schema
+                {:version 1
+                 :fields  [{:key :created-at :name "created_at" :type :instant}]})
+               [{:created-at (Date.)}])]
+    (is (= :collet.error/arrow-legacy-date (:collet.error/type (ex-data error)))))
+  (is (= :instant
+         (-> (sut/infer-schema! [{:created-at (Instant/parse "2026-01-01T00:00:00Z")}])
+             :fields
+             first
+             :type))))

--- a/collet-core/test/collet/core_test.clj
+++ b/collet-core/test/collet/core_test.clj
@@ -1,9 +1,13 @@
 (ns collet.core-test
   (:require
    [clojure.test :refer :all]
+   [collet.actions.mapper :as mapper]
+   [collet.actions.slicer :as slicer]
+   [collet.arrow :as arrow]
    [collet.core :as sut]
    [collet.test-fixtures :as tf]
-   [collet.utils :as utils]))
+   [collet.utils :as utils]
+   [tech.v3.dataset :as ds]))
 
 
 (use-fixtures :once (tf/instrument! 'collet.core))
@@ -133,94 +137,97 @@
 
 (deftest compile-and-run-task
   (testing "Compiles and runs a task"
-    (let [task-spec {:name    :test-task
-                     :actions [{:type   :clj/select-keys
-                                :name   :keys-selector
-                                :params [{:a 1 :b 2 :c 3 :d 4 :e 5}
-                                         [:a :b :e]]}
-                               {:type      :custom
-                                :name      :format-string
-                                :selectors '{a [:state :keys-selector :a]
-                                             b [:state :keys-selector :b]
-                                             e [:state :keys-selector :e]}
-                                :params    '[a b e]
-                                :fn        (fn [a b e]
-                                             (format "Params extracted a: %s, b: %s, e: %s"
-                                                     a b e))}]}
+    (let [task-spec         {:name    :test-task
+                             :actions [{:type   :clj/select-keys
+                                        :name   :keys-selector
+                                        :params [{:a 1 :b 2 :c 3 :d 4 :e 5}
+                                                 [:a :b :e]]}
+                                       {:type      :custom
+                                        :name      :format-string
+                                        :selectors '{a [:state :keys-selector :a]
+                                                     b [:state :keys-selector :b]
+                                                     e [:state :keys-selector :e]}
+                                        :params    '[a b e]
+                                        :fn        (fn [a b e]
+                                                     (format "Params extracted a: %s, b: %s, e: %s"
+                                                             a
+                                                             b
+                                                             e))}]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)
-          actual    (task-fn {:config {} :state {}})]
+          actual            (task-fn {:config {} :state {}})]
       (is (= actual "Params extracted a: 1, b: 2, e: 5"))))
 
   (testing "Task with setup actions"
-    (let [task-spec {:name    :test-task
-                     :setup   [{:type   :clj/select-keys
-                                :name   :keys-selector
-                                :params [{:a 1 :b 2 :c 3 :d 4 :e 5}
-                                         [:a :b :e]]}]
-                     :actions [{:type      :custom
-                                :name      :format-string
-                                :selectors '{a [:state :keys-selector :a]
-                                             b [:state :keys-selector :b]
-                                             e [:state :keys-selector :e]}
-                                :params    '[a b e]
-                                :fn        (fn [a b e]
-                                             (format "Params extracted a: %s, b: %s, e: %s"
-                                                     a b e))}]}
+    (let [task-spec         {:name    :test-task
+                             :setup   [{:type   :clj/select-keys
+                                        :name   :keys-selector
+                                        :params [{:a 1 :b 2 :c 3 :d 4 :e 5}
+                                                 [:a :b :e]]}]
+                             :actions [{:type      :custom
+                                        :name      :format-string
+                                        :selectors '{a [:state :keys-selector :a]
+                                                     b [:state :keys-selector :b]
+                                                     e [:state :keys-selector :e]}
+                                        :params    '[a b e]
+                                        :fn        (fn [a b e]
+                                                     (format "Params extracted a: %s, b: %s, e: %s"
+                                                             a
+                                                             b
+                                                             e))}]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)
-          actual    (task-fn {:config {} :state {}})]
+          actual            (task-fn {:config {} :state {}})]
       (is (= actual "Params extracted a: 1, b: 2, e: 5"))))
 
   (testing "Task with iterator"
-    (let [counter   (atom 0)
-          task-spec {:name     :test-task
-                     :actions  [{:type :custom
-                                 :name :count-action
-                                 :fn   (fn []
-                                         {:count (swap! counter inc)})}]
-                     :iterator {:next true}
-                     :return   [:state :count-action :count]}
+    (let [counter           (atom 0)
+          task-spec         {:name     :test-task
+                             :actions  [{:type :custom
+                                         :name :count-action
+                                         :fn   (fn []
+                                                 {:count (swap! counter inc)})}]
+                             :iterator {:next true}
+                             :return   [:state :count-action :count]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)
-          result    (task-fn {:config {} :state {}})]
+          result            (task-fn {:config {} :state {}})]
       ;; result becomes a sequence of what :data iterator property returns
       (is (= (take 10 result) (range 1 11)))
       (is (= (first result) 11))))
 
   (testing "Task with external actions"
-    (let [task-spec {:name    :test-task
-                     :actions [{:name   :count-action
-                                :type   :test.collet/counter-action.edn
-                                :params [0]}]
-                     ;; name of the action is overridden by the external action
-                     :return  [:state :my-external-action]}
+    (let [task-spec         {:name    :test-task
+                             :actions [{:name   :count-action
+                                        :type   :test.collet/counter-action.edn
+                                        :params [0]}]
+                             ;; name of the action is overridden by the external action
+                             :return  [:state :my-external-action]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)
-          result    (task-fn {:config {} :state {}})]
+          result            (task-fn {:config {} :state {}})]
       (is (= 1 result)))))
 
 
 (deftest handle-task-errors-test
   (testing "Tasks failed on error"
-    (let [task-spec {:name    :throwing-task
-                     :actions [{:type :custom
-                                :name :bad-action
-                                :fn   (fn []
-                                        (throw (ex-info "Bad action" {})))}]}
+    (let [task-spec         {:name    :throwing-task
+                             :actions [{:type :custom
+                                        :name :bad-action
+                                        :fn   (fn []
+                                                (throw (ex-info "Bad action" {})))}]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)]
       (is (thrown? Exception (task-fn {:config {} :state {}})))))
 
   (testing "Tasks retried on failure"
-    (let [runs-count (atom 0)
-          task-spec  {:name    :throwing-task
-                      :retry   {:max-retries 3}
-                      :actions [{:type :custom
-                                 :name :bad-action
-                                 :fn   (fn []
-                                         (swap! runs-count inc)
-                                         (throw (ex-info "Bad action" {})))}]}
+    (let [runs-count        (atom 0)
+          task-spec         {:name    :throwing-task
+                             :retry   {:max-retries 3}
+                             :actions [{:type :custom
+                                        :name :bad-action
+                                        :fn   (fn []
+                                                (swap! runs-count inc)
+                                                (throw (ex-info "Bad action" {})))}]}
           {:keys [task-fn]} (sut/compile-task (utils/eval-ctx) task-spec)]
       (is (thrown? Exception (task-fn {:config {} :state {}})))
       ;; function will be called 4 times: 1 initial run + 3 retries
       (is (= @runs-count 4)))))
-
 
 
 (deftest execute-task-test
@@ -277,3 +284,91 @@
           (is (= 2 (count result)))
           (is (= ["PR1" "PR2"]
                  (map :title result))))))))
+
+
+(deftest arrow-task-result-batching-test
+  (let [schema (arrow/normalize-schema
+                {:version 1
+                 :fields  [{:key :id :name "id" :type :int64}]})
+        rows   (with-meta (map #(hash-map :id %) (range 8200))
+                          {:arrow-columns schema})
+        result (sut/handle-task-result :lazy-rows rows {:use-arrow true :keep-result true})
+        data   (sut/arrow->dataset result)]
+    (is (sut/arrow-task-result? result))
+    (is (= [4096 4096 8] (mapv ds/row-count data)))
+    (is (= {:id 0} (first (ds/rows (first data)))))
+    (is (= {:id 8199} (last (ds/rows (last data)))))
+    (is (= schema (:arrow-columns (meta data)))))
+  (let [schema  (arrow/normalize-schema
+                 {:version 1
+                  :fields  [{:key :id :name "id" :type :int64}]})
+        batches (with-meta [[] [{:id 1} {:id 2}] [] [{:id 3}]]
+                           {:arrow-columns schema})
+        result  (sut/handle-task-result :batched-rows batches {:use-arrow true :keep-result true})]
+    (is (= [2 1] (mapv ds/row-count (sut/arrow->dataset result)))))
+  (let [error (try
+                (sut/handle-task-result :ambiguous
+                                        [{:profile {:name "Ada"}}]
+                                        {:use-arrow true :keep-result true})
+                (catch clojure.lang.ExceptionInfo error
+                  error))]
+    (is (= :collet.error/arrow-schema-required
+           (:collet.error/type (ex-data error)))))
+  (let [fallback (with-meta (map identity [{:json {:a 1}}])
+                            {:collet.arrow/skip-conversion? true})
+        result   (sut/handle-task-result :jdbc-json-fallback
+                                         fallback
+                                         {:use-arrow true :keep-result true})]
+    (is (not (sut/arrow-task-result? result)))
+    (is (= [{:json {:a 1}}] (vec result)))
+    (is (true? (-> result meta :collet.arrow/skip-conversion?))))
+  (let [schema   (arrow/normalize-schema
+                  {:version 1
+                   :fields  [{:key :id :name "id" :type :int64}]})
+        view     (with-meta [(ds/->dataset [{:id 1}])
+                             (ds/->dataset [{:id 2} {:id 3}])]
+                            {:ds-seq true})
+        result   (sut/handle-task-result :arrow-view view {:use-arrow true :keep-result true})
+        datasets (sut/arrow->dataset result)]
+    (is (sut/arrow-task-result? result))
+    (is (= [1 2] (mapv ds/row-count datasets)))
+    (is (= [{:id 1} {:id 2} {:id 3}]
+           (vec (mapcat ds/rows datasets))))
+    (is (= schema (:arrow-columns (meta datasets))))))
+
+
+(deftest arrow-task-result-consumer-test
+  (let [schema   (arrow/normalize-schema
+                  {:version 1
+                   :fields  [{:key :id :name "id" :type :int64}
+                             {:key    :profile
+                              :name   "profile"
+                              :type   :struct
+                              :fields [{:key :name :name "name" :type :string}
+                                       {:key :score :name "score" :type :int32}]}
+                             {:key     :events
+                              :name    "events"
+                              :type    :list
+                              :element {:type   :struct
+                                        :fields [{:key :kind :name "kind" :type :string}]}}]})
+        rows     (with-meta [{:id      1
+                              :profile {:name "Ada" :score 7}
+                              :events  [{:kind "created"}]}
+                             {:id      2
+                              :profile nil
+                              :events  []}]
+                            {:arrow-columns schema})
+        result   (sut/handle-task-result :nested-rows rows {:use-arrow true :keep-result true})
+        datasets (sut/arrow->dataset result)
+        mapped   (mapper/map-sequence {:sequence datasets} nil)
+        sliced   (slicer/concat-dataset-seq datasets)]
+    (is (= {:id      1
+            :profile {:name "Ada" :score 7}
+            :events  [{:kind "created"}]}
+           (:current mapped)))
+    (is (= schema (:arrow-columns (meta sliced))))
+    (is (= [{:id      1
+             :profile {:name "Ada" :score 7}
+             :events  [{:kind "created"}]}
+            {:id 2 :profile nil :events []}]
+           (mapv #(arrow/prep-record % schema) (ds/rows sliced))))))

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,8 @@
  :paths []
 
  :deps
- {io.velio/collet-core          {:local/root "collet-core"}
+ {org.clojure/clojure           {:mvn/version "1.12.5"}
+  io.velio/collet-core          {:local/root "collet-core"}
   io.velio/collet-action-http   {:local/root "collet-action-http"}
   io.velio/collet-action-file   {:local/root "collet-action-file"}
   io.velio/collet-action-odata  {:local/root "collet-action-odata"}

--- a/docs/adr/0045-dataset-artifact-spike.md
+++ b/docs/adr/0045-dataset-artifact-spike.md
@@ -233,9 +233,11 @@ uploaded.
   keep Arrow IPC/JDBC Arrow as the integration boundary and offer DuckTape only
   as an optional object-column view. Its fixed-size-array gap and omitted
   top-level nil keys prevent it from defining Collet's artifact contract.
-- **#46:** define the nested JDBC Arrow boundary, including null parents, null
-  children, null list elements, maps, structs, lists, and fixed-size floats,
-  without JSON coercion; document Parquet's manifest-driven `FLOAT[n]` cast.
+- **#46:** Arrow IPC now owns the versioned nested record-batch schema:
+  null parents, null children, null list elements, maps, structs, lists,
+  fixed-size floats, exact decimals, and Java Time values without JSON
+  coercion. Issue #48 consumes this schema to restore Parquet's
+  manifest-driven FLOAT[n] logical cast.
 - **#48:** implement format-neutral artifact and snapshot identities with a
   Parquet/DuckDB storage adapter, immutable publication, checksums, recovery,
   and object-store behavior. Do not copy Lance's internal version model into

--- a/docs/arrow.md
+++ b/docs/arrow.md
@@ -1,0 +1,121 @@
+# Arrow record-batch boundary
+
+Collet uses Arrow IPC for temporary task-result interchange. This document
+defines the boundary owned by issue #46. It is separate from immutable Parquet
+artifacts in issue #48 and optional DuckDB/DuckTape execution in issue #47.
+
+## Explicit schema metadata
+
+Attach the schema as :arrow-columns metadata to a sequential task result. The
+schema is EDN-safe, versioned, and ordered:
+
+~~~clojure
+{:version 1
+ :fields
+ [{:key :id :name "id" :type :int64}
+  {:key :address
+   :name "address"
+   :type :struct
+   :fields [{:key :line :name "line" :type :string}
+            {:key :zip :name "zip" :type :int32 :nullable? false}]}
+  {:key :attributes :name "attributes" :type :map}
+  {:key :events
+   :name "events"
+   :type :list
+   :element {:type :struct
+             :fields [{:key :kind :name "kind" :type :string}
+                      {:key :score :name "score" :type :int32}]}}
+  {:key :embedding
+   :name "embedding"
+   :type :fixed-size-list
+   :size 768
+   :element {:type :float32 :nullable? false}}
+  {:key :amount
+   :name "amount"
+   :type :decimal
+   :bit-width 128
+   :precision 18
+   :scale 2}
+  {:key :external-id
+   :name "external_id"
+   :type :decimal
+   :bit-width 256
+   :precision 76
+   :scale 0
+   :logical-type :big-integer}]}
+~~~
+
+Every field has an application key, a physical Arrow name, a type, and an
+optional nullable flag. Nullable defaults to true. Struct fields use the same
+shape and are ordered. List elements are descriptors rather than named fields.
+
+Legacy [key physical-name type] column triplets remain accepted and normalize
+to this schema. New producers should emit the schema map.
+
+## Type contract
+
+| Shape | Arrow representation | Clojure value |
+| --- | --- | --- |
+| Scalar | Existing Arrow scalar types | Boolean, integer, floating point, String, UUID, Java Time, Duration |
+| Struct | Fixed ordered fields | Map with declared keys only |
+| Map | Non-null UTF-8 keys and nullable UTF-8 values | Map from String to String or nil |
+| List | Nullable element descriptor | Sequential value, read as vector |
+| Fixed embedding | FixedSizeList<Float32> | Vector of exactly the declared size |
+| Decimal | Decimal128 or Decimal256 | BigDecimal, or BigInteger with logical type |
+
+Struct is not Map: a Struct rejects extra keys and checks every non-nullable
+child. Arrow Map is intentionally limited to dynamic UTF-8 keys and values.
+Nil parent values, empty collections, nil list elements, and nil children are
+distinct and round-trip separately.
+
+## Inference and ambiguity
+
+Without metadata, Collet infers only unambiguous scalars, Java Time values, and
+homogeneous lists of scalars from the first 200 records in encounter order.
+Struct-versus-Map values, fixed-size lists, all-null fields, empty/all-null
+lists, mixed nested values, BigInteger, and BigDecimal require metadata.
+
+At the core task-result boundary, a pipeline with :use-arrow true raises
+:collet.error/arrow-schema-required instead of silently retaining ambiguous
+data in memory. Setting :use-arrow false keeps the legacy in-memory behavior.
+The JDBC action retains its best-effort JSON fallback when it has no explicit
+schema.
+
+## Numeric and temporal rules
+
+All signed and unsigned integer widths are checked before writing. Decimal128
+supports precision through 38 and Decimal256 through 76. BigDecimal must fit
+the declared precision and scale exactly; required rounding and overflow fail.
+Logical BigInteger uses decimal scale zero and Arrow field metadata.
+
+Use Instant, LocalDate, LocalDateTime, or LocalTime. java.util.Date and all
+of its subclasses are rejected rather than normalized implicitly.
+
+## Batching and TMD views
+
+Flat lazy results are written as private 4,096-row Arrow record batches.
+Already batched output, including TMD dataset sequences, is written while
+retaining its non-empty batch boundaries. No whole-result counting or random
+sampling is used.
+
+Scalar-only schemas retain the memory-mapped tech.ml.dataset reader. A schema
+with nested or extended values is read one Arrow batch at a time into TMD
+object columns: Struct and Map become Clojure maps, Lists become vectors, and
+decimal values become BigDecimal or logical BigInteger. That view copies only
+the requested bounded batch into heap; it does not make the complete IPC file
+resident. The schema metadata stays attached so prep-record can restore
+top-level nil keys that TMD omits from row maps.
+
+Readers, channels, and allocators close at EOF or error, with resource tracking
+as the abandonment fallback.
+
+## Errors
+
+Conversion failures are ExceptionInfo values with a short, path-aware payload:
+
+- :collet.error/type identifies schema, value, legacy-date, or schema-required
+  failure.
+- :path identifies a row, field, list index, and nested child.
+- :expected, :reason, and :actual-class explain the failed conversion.
+
+The error payload deliberately excludes complete rows and batches.


### PR DESCRIPTION
## Summary

- define a versioned recursive Arrow 19 schema contract on existing `:arrow-columns` metadata
- round-trip Struct, Map, List, List of Struct, fixed Float32 embeddings, Decimal128/256, logical BigInteger, Java Time values, and nested nulls
- keep flat lazy results bounded to 4,096-row batches while preserving existing TMD record-batch boundaries
- retain scalar memory-mapped TMD reads and expose nested batches as bounded object-column views
- preserve JDBC schema-less JSON fallback and propagate Arrow metadata through core consumers
- document the schema grammar, ambiguity rules, value/error contract, batching, and ADR follow-ups

Arrow IPC remains the temporary task-result interchange boundary. Parquet publication stays in #48, and DuckDB/DuckTape execution stays in #47.

## Validation

- focused `collet.arrow-test`: 25 tests, 236 assertions
- `bb test:module collet-core`: 73 tests, 572 assertions
- `bb test:unit`
- `bb test:integration`
- `bb verify`
- `bb release:plan` (read-only; planned 0.2.9, no release run)
- changed-file formatter checks
- `git diff --check`
- root nREPL reload plus preferred and fallback client evaluation on Clojure 1.12.5

Closes #46
